### PR TITLE
[#2] - Research: prototype physical device detection using raw input

### DIFF
--- a/docs/research/feasibility-notes.md
+++ b/docs/research/feasibility-notes.md
@@ -11,6 +11,18 @@ This file is the running log for early technical spikes. It should capture evide
 
 ## Raw Input Feasibility
 
+### Objective
+
+Determine whether Windows Raw Input can reliably distinguish between multiple physical keyboards and mice connected to the same system, and whether the identifiers exposed are usable enough to support later mapping decisions.
+
+### Implementation Summary
+
+- Prototype project: `prototypes/raw-input-test/RawInputPrototype`
+- Windows-only WPF harness
+- Registers for raw keyboard and mouse input
+- Logs `WM_INPUT` events with source device handle, parsed identifier, and event summary
+- Enumerates current keyboard and mouse devices using Raw Input device APIs
+
 ### Questions
 
 - Can Windows reliably distinguish between multiple physical keyboards?
@@ -19,7 +31,23 @@ This file is the running log for early technical spikes. It should capture evide
 
 ### Findings
 
-- No findings recorded yet.
+- Prototype harness added; empirical findings are still pending manual testing on Windows hardware.
+- No behaviour conclusions recorded yet.
+
+### Manual Test Checklist
+
+- Connect two keyboards and press keys on each in separate bursts.
+- Connect two mice if available and move or click each in separate bursts.
+- Compare the logged device handles and identifiers between the devices.
+- Note whether identifiers remain stable while the app stays open.
+- Optionally disconnect and reconnect one device to record whether the handle or identifier changes.
+
+### Evidence To Record
+
+- screenshot of the device snapshot table
+- copied event log excerpt showing distinct devices
+- Windows version and hardware notes
+- reconnect observations if tested
 
 ## Display Switching Feasibility
 

--- a/docs/research/raw-input-feasibility.md
+++ b/docs/research/raw-input-feasibility.md
@@ -1,0 +1,56 @@
+# Raw Input Feasibility Log
+
+This document is a focused evidence template for the Raw Input prototype. Fill it in after running the prototype on real hardware. Do not record assumptions as findings.
+
+## Objective
+
+Determine whether Windows Raw Input can reliably distinguish between multiple physical keyboards and mice connected to the same system.
+
+## Prototype Location
+
+- `prototypes/raw-input-test/RawInputPrototype`
+
+## Implementation Summary
+
+- WPF desktop window
+- Raw Input registration for keyboards and mice
+- `WM_INPUT` parsing for keyboard and mouse activity
+- device snapshot populated from `GetRawInputDeviceList` and `GetRawInputDeviceInfo`
+- live bounded event log showing timestamp, source handle, identifier, and event summary
+
+## Environment Under Test
+
+Fill this table in for each manual run.
+
+| Date | Windows version | .NET SDK/runtime | Devices connected | Notes |
+| --- | --- | --- | --- | --- |
+| _pending_ | _pending_ | _pending_ | _pending_ | _pending_ |
+
+## Manual Test Procedure
+
+1. Launch the prototype from Windows.
+2. Confirm the device snapshot shows the connected keyboards and mice you want to compare.
+3. Press several keys on keyboard A, then keyboard B.
+4. Move and click mouse A, then mouse B if available.
+5. Compare the logged device handles and identifiers for each physical device.
+6. Refresh the device snapshot if you reconnect hardware.
+7. Optionally disconnect and reconnect one device to observe handle or identifier changes.
+
+## Evidence Checklist
+
+- screenshot of the device snapshot table
+- copied event log excerpt showing at least one sequence from each physical device
+- notes on exact hardware involved
+- notes on whether identifiers stayed stable during the run
+- notes on reconnect behavior if tested
+
+## Findings
+
+- Manual findings pending.
+
+## Open Questions
+
+- Are device handles stable across separate launches of the prototype?
+- Do common wireless receivers expose distinct enough identifiers for multiple devices?
+- Do integrated laptop devices behave differently from external USB devices?
+- Is Raw Input alone sufficient, or will later mapping need extra metadata from other Windows APIs?

--- a/prototypes/raw-input-test/README.md
+++ b/prototypes/raw-input-test/README.md
@@ -1,30 +1,115 @@
 # Raw Input Prototype
 
-This prototype area is reserved for investigating whether Windows can distinguish physical keyboards and mice closely enough for the planned application.
+This folder contains a Windows-only feasibility harness for Issue #2. Its job is to answer one question: can Windows Raw Input distinguish between multiple physical keyboards and mice connected to the same machine?
 
-## Objective
+## Prototype Purpose
 
-Determine whether Raw Input can provide device-specific activity information that is reliable enough to map physical input devices to logical zones.
+The prototype does not try to implement the future application. It only:
 
-## What Will Be Tested
+- registers for keyboard and mouse Raw Input
+- listens for `WM_INPUT` and `WM_INPUT_DEVICE_CHANGE`
+- logs which device produced each event
+- shows a snapshot of currently detected keyboard and mouse devices
+- exposes enough detail to compare two physical devices manually
 
-- detection of multiple keyboards
-- detection of multiple mice
-- availability of per-device identifiers
-- consistency of identifiers across repeated runs and reconnects
-- behaviour differences across wired, wireless, and mixed-device setups where available
+The runnable project lives at `prototypes/raw-input-test/RawInputPrototype`.
 
-## Evidence To Collect
+## What It Tests
 
-- observed device identifiers
-- example input event traces
-- notes on devices that cannot be distinguished reliably
-- notes on reconnect and reboot behaviour
+- whether keyboard events include a device-specific source handle
+- whether mouse events include a device-specific source handle
+- whether Raw Input exposes a stable device path or identifier while the app is running
+- whether two physical keyboards and/or two physical mice appear as distinct event sources
+- whether reconnecting a device triggers useful arrival and removal information
 
-## Success Criteria
+## What The Window Shows
 
-- the prototype can distinguish the target input devices with useful consistency
-- the information exposed is sufficient to support a future device registry
-- any important limitations are clearly documented for design decisions
+The WPF window has two sections:
 
-No production implementation belongs here yet; this folder is only for a focused feasibility spike.
+- a device snapshot table with device type, handle, parsed VID/PID when available, raw device path, and type-specific details
+- a bounded live event log with timestamp, event type, foreground/background source, device handle, identifier, and an event summary
+
+The event log is capped at 300 entries so the UI stays usable during manual testing.
+
+## How to Run
+
+Run this from Windows, not WSL. WPF and Raw Input are Windows-only.
+
+1. Install the .NET 8 SDK on Windows if it is not already installed.
+2. Open Windows Terminal, PowerShell, or a Developer Command Prompt.
+3. Change into the project directory:
+
+```powershell
+cd .\prototypes\raw-input-test\RawInputPrototype
+```
+
+4. Launch the prototype:
+
+```powershell
+dotnet run
+```
+
+You can also open `RawInputPrototype.csproj` in Visual Studio 2022 and run it there.
+
+## Exact Manual Test Steps
+
+Use these steps to test with two keyboards or two mice:
+
+1. Connect at least two keyboards and/or two mice to the same Windows machine.
+2. Start the prototype and leave it open.
+3. Check the device snapshot table first.
+4. Identify whether the table shows separate rows for the devices you plan to test.
+5. Press a key on keyboard A several times.
+6. Press a different key on keyboard B several times.
+7. Compare the `Handle` and `Device` values in the live event log for keyboard A versus keyboard B.
+8. If you have two mice, move mouse A, click once or twice, then repeat with mouse B.
+9. Compare the `Handle` and `Device` values in the live event log for mouse A versus mouse B.
+10. Disconnect and reconnect one device if you want to observe arrival/removal behavior and whether the identifier changes.
+
+## What To Look For
+
+During testing, focus on whether:
+
+- keyboard A and keyboard B generate different device handles and/or identifiers
+- mouse A and mouse B generate different device handles and/or identifiers
+- the same physical device keeps the same identifier while the app remains open
+- the snapshot metadata matches the devices that are generating events
+- reconnecting a device changes the identifier or device handle unexpectedly
+
+## What Counts As Success Or Failure
+
+Success for this prototype means:
+
+- the window receives raw keyboard and mouse input events
+- each event can be associated with a device handle
+- at least two physical keyboards and/or two physical mice can be told apart by the identifiers shown in the UI
+
+Partial success means:
+
+- events are received and handles differ, but the metadata is noisy, incomplete, or inconsistent enough that more research is needed
+
+Failure means:
+
+- raw events are not received reliably
+- multiple physical devices collapse into the same source identity
+- the available identifiers are too unstable or ambiguous to support later mapping logic
+
+## Evidence To Capture
+
+Record real observations only. Useful evidence includes:
+
+- a screenshot of the device snapshot table
+- copied event log entries showing keyboard A versus keyboard B and/or mouse A versus mouse B
+- Windows version, device models, and connection type notes
+- reconnect observations, including whether handles or identifiers changed
+
+The `Copy Event Log` button copies the current visible log rows to the clipboard to make this easier.
+
+## Limitations
+
+- This is a feasibility spike, not production architecture.
+- It does not switch displays, define zones, store mappings, or persist anything.
+- It relies on Raw Input device handles, device paths, and parsed VID/PID values when available.
+- It does not currently resolve polished human-friendly device names through SetupAPI or other device-enumeration layers.
+- Some hardware setups may surface composite devices, shared receivers, or integrated devices in ways that need further interpretation.
+- The prototype uses `RIDEV_INPUTSINK`, so it can continue receiving input while the window remains open in the background.

--- a/prototypes/raw-input-test/RawInputPrototype/App.xaml
+++ b/prototypes/raw-input-test/RawInputPrototype/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="RawInputPrototype.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+  <Application.Resources>
+  </Application.Resources>
+</Application>

--- a/prototypes/raw-input-test/RawInputPrototype/App.xaml.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/App.xaml.cs
@@ -1,0 +1,5 @@
+namespace RawInputPrototype;
+
+public partial class App : System.Windows.Application
+{
+}

--- a/prototypes/raw-input-test/RawInputPrototype/MainWindow.xaml
+++ b/prototypes/raw-input-test/RawInputPrototype/MainWindow.xaml
@@ -1,0 +1,122 @@
+<Window x:Class="RawInputPrototype.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Raw Input Feasibility Prototype"
+        Width="1500"
+        Height="860"
+        MinWidth="1100"
+        MinHeight="700">
+  <Grid Margin="12">
+    <Grid.RowDefinitions>
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
+      <RowDefinition Height="2*" />
+      <RowDefinition Height="3*" />
+    </Grid.RowDefinitions>
+
+    <StackPanel Grid.Row="0"
+                Margin="0,0,0,12">
+      <TextBlock FontSize="22"
+                 FontWeight="SemiBold"
+                 Text="Windows Raw Input Feasibility Harness" />
+      <TextBlock Margin="0,6,0,0"
+                 TextWrapping="Wrap">
+        This prototype listens for Raw Input keyboard and mouse events, shows which device produced each event,
+        and keeps a snapshot of currently detected keyboard and mouse devices so you can compare identifiers while testing.
+      </TextBlock>
+    </StackPanel>
+
+    <DockPanel Grid.Row="1"
+               Margin="0,0,0,12"
+               LastChildFill="False">
+      <TextBlock x:Name="StatusTextBlock"
+                 VerticalAlignment="Center"
+                 TextWrapping="Wrap" />
+      <StackPanel DockPanel.Dock="Right"
+                  Orientation="Horizontal">
+        <Button Margin="12,0,0,0"
+                Padding="12,6"
+                Click="RefreshDevicesButton_Click"
+                Content="Refresh Devices" />
+        <Button Margin="12,0,0,0"
+                Padding="12,6"
+                Click="CopyLogButton_Click"
+                Content="Copy Event Log" />
+        <Button Margin="12,0,0,0"
+                Padding="12,6"
+                Click="ClearLogButton_Click"
+                Content="Clear Log" />
+      </StackPanel>
+    </DockPanel>
+
+    <GroupBox Grid.Row="2"
+              Header="Detected input devices (snapshot)"
+              Margin="0,0,0,12">
+      <DataGrid x:Name="DevicesDataGrid"
+                AutoGenerateColumns="False"
+                CanUserAddRows="False"
+                CanUserDeleteRows="False"
+                EnableRowVirtualization="True"
+                IsReadOnly="True"
+                HeadersVisibility="Column"
+                SelectionMode="Single">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Type"
+                              Binding="{Binding DeviceTypeText}"
+                              Width="110" />
+          <DataGridTextColumn Header="Handle"
+                              Binding="{Binding DeviceHandleText}"
+                              Width="160" />
+          <DataGridTextColumn Header="VID"
+                              Binding="{Binding VendorId}"
+                              Width="85" />
+          <DataGridTextColumn Header="PID"
+                              Binding="{Binding ProductId}"
+                              Width="85" />
+          <DataGridTextColumn Header="Identifier"
+                              Binding="{Binding Identifier}"
+                              Width="220" />
+          <DataGridTextColumn Header="Device Path"
+                              Binding="{Binding DeviceName}"
+                              Width="*" />
+          <DataGridTextColumn Header="Details"
+                              Binding="{Binding Details}"
+                              Width="280" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </GroupBox>
+
+    <GroupBox Grid.Row="3"
+              Header="Live raw input event log">
+      <DataGrid x:Name="EventsDataGrid"
+                AutoGenerateColumns="False"
+                CanUserAddRows="False"
+                CanUserDeleteRows="False"
+                EnableRowVirtualization="True"
+                IsReadOnly="True"
+                HeadersVisibility="Column"
+                SelectionMode="Single">
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Timestamp"
+                              Binding="{Binding TimestampText}"
+                              Width="170" />
+          <DataGridTextColumn Header="Type"
+                              Binding="{Binding EventType}"
+                              Width="95" />
+          <DataGridTextColumn Header="Source"
+                              Binding="{Binding InputSource}"
+                              Width="100" />
+          <DataGridTextColumn Header="Handle"
+                              Binding="{Binding DeviceHandle}"
+                              Width="160" />
+          <DataGridTextColumn Header="Device"
+                              Binding="{Binding DeviceLabel}"
+                              Width="260" />
+          <DataGridTextColumn Header="Summary"
+                              Binding="{Binding Summary}"
+                              Width="*" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </GroupBox>
+  </Grid>
+</Window>

--- a/prototypes/raw-input-test/RawInputPrototype/MainWindow.xaml.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/MainWindow.xaml.cs
@@ -1,0 +1,269 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Text;
+using System.Windows;
+using System.Windows.Interop;
+using RawInputPrototype.RawInput;
+
+namespace RawInputPrototype;
+
+public partial class MainWindow : Window
+{
+    private const int MaxEventEntries = 300;
+
+    private readonly ObservableCollection<RawInputDeviceInfo> _devices = [];
+    private readonly ObservableCollection<RawInputEvent> _events = [];
+    private readonly Dictionary<nint, RawInputDeviceInfo> _deviceCache = [];
+    private readonly DeviceInfoProvider _deviceInfoProvider = new();
+
+    private HwndSource? _windowSource;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        DevicesDataGrid.ItemsSource = _devices;
+        EventsDataGrid.ItemsSource = _events;
+
+        SourceInitialized += MainWindow_SourceInitialized;
+        Closing += MainWindow_Closing;
+
+        UpdateStatus("Waiting for window handle so Raw Input registration can start.");
+    }
+
+    private void MainWindow_SourceInitialized(object? sender, EventArgs e)
+    {
+        _windowSource = (HwndSource?)PresentationSource.FromVisual(this);
+
+        if (_windowSource is null)
+        {
+            UpdateStatus("Unable to acquire the window handle needed for Raw Input registration.");
+            return;
+        }
+
+        _windowSource.AddHook(WndProc);
+
+        try
+        {
+            RawInputRegistration.RegisterKeyboardAndMouse(_windowSource.Handle);
+            RefreshDeviceSnapshot();
+            AppendSystemEvent("Raw Input registration succeeded. Keyboard and mouse activity will now be logged.");
+        }
+        catch (Win32Exception exception)
+        {
+            UpdateStatus($"Raw Input registration failed: {exception.Message}");
+            AppendSystemEvent($"Raw Input registration failed: {exception.Message}");
+        }
+    }
+
+    private void MainWindow_Closing(object? sender, CancelEventArgs e)
+    {
+        if (_windowSource is not null)
+        {
+            _windowSource.RemoveHook(WndProc);
+        }
+    }
+
+    private nint WndProc(nint hwnd, int msg, nint wParam, nint lParam, ref bool handled)
+    {
+        switch (msg)
+        {
+            case RawInputInterop.WM_INPUT:
+                HandleRawInput(wParam, lParam);
+                break;
+            case RawInputInterop.WM_INPUT_DEVICE_CHANGE:
+                HandleDeviceChange(wParam, lParam);
+                break;
+        }
+
+        handled = false;
+        return nint.Zero;
+    }
+
+    private void HandleRawInput(nint wParam, nint lParam)
+    {
+        if (!RawInputParser.TryReadEvent(lParam, wParam, out var parsedEvent, out var error))
+        {
+            AppendSystemEvent($"Failed to parse WM_INPUT: {error}");
+            return;
+        }
+
+        if (parsedEvent is null)
+        {
+            AppendSystemEvent("Received WM_INPUT with no parsed event payload.");
+            return;
+        }
+
+        AppendEvent(CreateDisplayEvent(parsedEvent));
+    }
+
+    private void HandleDeviceChange(nint wParam, nint lParam)
+    {
+        var deviceHandle = lParam;
+        var changeSummary = wParam.ToInt64() switch
+        {
+            RawInputInterop.GIDC_ARRIVAL => "Device arrival detected.",
+            RawInputInterop.GIDC_REMOVAL => "Device removal detected.",
+            _ => $"Device change message received with code {wParam.ToInt64()}."
+        };
+
+        var deviceInfo = GetDeviceInfo(deviceHandle, RawInputDeviceType.Unknown);
+
+        AppendEvent(new RawInputEvent
+        {
+            Timestamp = DateTime.Now,
+            EventType = "Device",
+            InputSource = "System",
+            DeviceHandle = RawInputInterop.FormatHandle(deviceHandle),
+            DeviceLabel = deviceInfo.DisplayLabel,
+            Summary = changeSummary
+        });
+
+        RefreshDeviceSnapshot();
+    }
+
+    private RawInputEvent CreateDisplayEvent(ParsedRawInputEvent parsedEvent)
+    {
+        var deviceInfo = GetDeviceInfo(parsedEvent.DeviceHandle, parsedEvent.DeviceType);
+
+        return new RawInputEvent
+        {
+            Timestamp = parsedEvent.Timestamp,
+            EventType = parsedEvent.DeviceTypeText,
+            InputSource = parsedEvent.InputSource,
+            DeviceHandle = RawInputInterop.FormatHandle(parsedEvent.DeviceHandle),
+            DeviceLabel = deviceInfo.DisplayLabel,
+            Summary = parsedEvent.Summary
+        };
+    }
+
+    private RawInputDeviceInfo GetDeviceInfo(nint deviceHandle, RawInputDeviceType deviceType)
+    {
+        if (_deviceCache.TryGetValue(deviceHandle, out var cached))
+        {
+            return cached;
+        }
+
+        RawInputDeviceInfo deviceInfo;
+
+        if (deviceHandle == nint.Zero)
+        {
+            deviceInfo = RawInputDeviceInfo.CreateFallback(deviceHandle, deviceType, "Windows did not provide a device handle for this event.");
+        }
+        else
+        {
+            deviceInfo = _deviceInfoProvider.TryGetDeviceInfo(deviceHandle, deviceType)
+                ?? RawInputDeviceInfo.CreateFallback(deviceHandle, deviceType, "Device metadata could not be resolved.");
+        }
+
+        _deviceCache[deviceHandle] = deviceInfo;
+        return deviceInfo;
+    }
+
+    private void RefreshDeviceSnapshot()
+    {
+        try
+        {
+            var devices = _deviceInfoProvider.GetCurrentDevices();
+
+            _devices.Clear();
+
+            foreach (var device in devices)
+            {
+                _devices.Add(device);
+                _deviceCache[device.DeviceHandle] = device;
+            }
+
+            UpdateStatus($"Listening for Raw Input events. Snapshot contains {_devices.Count} keyboard/mouse devices. Event log keeps the latest {MaxEventEntries} entries.");
+        }
+        catch (Win32Exception exception)
+        {
+            UpdateStatus($"Failed to refresh device snapshot: {exception.Message}");
+            AppendSystemEvent($"Failed to refresh device snapshot: {exception.Message}");
+        }
+    }
+
+    private void AppendSystemEvent(string summary)
+    {
+        AppendEvent(new RawInputEvent
+        {
+            Timestamp = DateTime.Now,
+            EventType = "System",
+            InputSource = "Window",
+            DeviceHandle = RawInputInterop.FormatHandle(nint.Zero),
+            DeviceLabel = "Prototype",
+            Summary = summary
+        });
+    }
+
+    private void AppendEvent(RawInputEvent entry)
+    {
+        _events.Add(entry);
+
+        while (_events.Count > MaxEventEntries)
+        {
+            _events.RemoveAt(0);
+        }
+
+        if (_events.Count > 0)
+        {
+            EventsDataGrid.ScrollIntoView(_events[^1]);
+        }
+
+        UpdateStatus($"Listening for Raw Input events. Snapshot contains {_devices.Count} keyboard/mouse devices. Event log: {_events.Count}/{MaxEventEntries} entries.");
+    }
+
+    private void UpdateStatus(string message)
+    {
+        StatusTextBlock.Text = message;
+    }
+
+    private void RefreshDevicesButton_Click(object sender, RoutedEventArgs e)
+    {
+        RefreshDeviceSnapshot();
+        AppendSystemEvent("Device snapshot refreshed.");
+    }
+
+    private void ClearLogButton_Click(object sender, RoutedEventArgs e)
+    {
+        _events.Clear();
+        UpdateStatus($"Listening for Raw Input events. Snapshot contains {_devices.Count} keyboard/mouse devices. Event log cleared.");
+    }
+
+    private void CopyLogButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (_events.Count == 0)
+        {
+            UpdateStatus("There are no event log entries to copy yet.");
+            return;
+        }
+
+        var builder = new StringBuilder();
+
+        foreach (var entry in _events)
+        {
+            builder.Append(entry.TimestampText)
+                .Append('\t')
+                .Append(entry.EventType)
+                .Append('\t')
+                .Append(entry.InputSource)
+                .Append('\t')
+                .Append(entry.DeviceHandle)
+                .Append('\t')
+                .Append(entry.DeviceLabel)
+                .Append('\t')
+                .Append(entry.Summary)
+                .AppendLine();
+        }
+
+        try
+        {
+            Clipboard.SetText(builder.ToString());
+            UpdateStatus($"Copied {_events.Count} event log entries to the clipboard.");
+        }
+        catch (Exception exception)
+        {
+            UpdateStatus($"Could not copy the event log to the clipboard: {exception.Message}");
+        }
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/DeviceInfoProvider.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/DeviceInfoProvider.cs
@@ -1,0 +1,213 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace RawInputPrototype.RawInput;
+
+internal sealed class DeviceInfoProvider
+{
+    private static readonly Regex VidPidRegex = new(@"VID_([0-9A-F]{4}).*PID_([0-9A-F]{4})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public IReadOnlyList<RawInputDeviceInfo> GetCurrentDevices()
+    {
+        var devices = new List<RawInputDeviceInfo>();
+        uint deviceCount = 0;
+
+        var countResult = RawInputInterop.GetRawInputDeviceList(
+            nint.Zero,
+            ref deviceCount,
+            (uint)Marshal.SizeOf<RawInputInterop.RAWINPUTDEVICELIST>());
+
+        if (countResult == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        if (deviceCount == 0)
+        {
+            return devices;
+        }
+
+        var elementSize = Marshal.SizeOf<RawInputInterop.RAWINPUTDEVICELIST>();
+        var buffer = Marshal.AllocHGlobal((int)(deviceCount * elementSize));
+
+        try
+        {
+            var listResult = RawInputInterop.GetRawInputDeviceList(
+                buffer,
+                ref deviceCount,
+                (uint)elementSize);
+
+            if (listResult == uint.MaxValue)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            for (var index = 0; index < deviceCount; index++)
+            {
+                var current = buffer + (index * elementSize);
+                var deviceEntry = Marshal.PtrToStructure<RawInputInterop.RAWINPUTDEVICELIST>(current);
+                var deviceType = ToDeviceType(deviceEntry.dwType);
+
+                if (deviceType is RawInputDeviceType.Keyboard or RawInputDeviceType.Mouse)
+                {
+                    devices.Add(TryGetDeviceInfo(deviceEntry.hDevice, deviceType)
+                        ?? RawInputDeviceInfo.CreateFallback(deviceEntry.hDevice, deviceType, "Device metadata could not be resolved."));
+                }
+            }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+
+        return devices
+            .OrderBy(device => device.DeviceType)
+            .ThenBy(device => device.Identifier, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(device => device.DeviceName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public RawInputDeviceInfo? TryGetDeviceInfo(nint deviceHandle, RawInputDeviceType fallbackType = RawInputDeviceType.Unknown)
+    {
+        if (deviceHandle == nint.Zero)
+        {
+            return RawInputDeviceInfo.CreateFallback(deviceHandle, fallbackType, "Windows reported this event without a device handle.");
+        }
+
+        try
+        {
+            var info = GetDeviceInfo(deviceHandle);
+            var deviceType = ToDeviceType(info.dwType);
+            var name = GetDeviceName(deviceHandle);
+            var (vendorId, productId) = ParseVidPid(name, info);
+
+            return new RawInputDeviceInfo
+            {
+                DeviceHandle = deviceHandle,
+                DeviceType = deviceType == RawInputDeviceType.Unknown ? fallbackType : deviceType,
+                DeviceName = string.IsNullOrWhiteSpace(name) ? "(device name unavailable)" : name,
+                VendorId = vendorId,
+                ProductId = productId,
+                Identifier = BuildIdentifier(deviceType == RawInputDeviceType.Unknown ? fallbackType : deviceType, vendorId, productId, name),
+                Details = BuildDetails(info)
+            };
+        }
+        catch (Win32Exception)
+        {
+            return null;
+        }
+    }
+
+    private static RawInputInterop.RID_DEVICE_INFO GetDeviceInfo(nint deviceHandle)
+    {
+        var info = new RawInputInterop.RID_DEVICE_INFO
+        {
+            cbSize = (uint)Marshal.SizeOf<RawInputInterop.RID_DEVICE_INFO>()
+        };
+
+        var size = info.cbSize;
+        var result = RawInputInterop.GetRawInputDeviceInfo(deviceHandle, RawInputInterop.RIDI_DEVICEINFO, ref info, ref size);
+
+        if (result == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        return info;
+    }
+
+    private static string GetDeviceName(nint deviceHandle)
+    {
+        uint size = 0;
+
+        var queryResult = RawInputInterop.GetRawInputDeviceInfo(deviceHandle, RawInputInterop.RIDI_DEVICENAME, nint.Zero, ref size);
+        if (queryResult == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        if (size == 0)
+        {
+            return string.Empty;
+        }
+
+        var buffer = Marshal.AllocHGlobal((int)(size * sizeof(char)));
+
+        try
+        {
+            var nameSize = size;
+            var nameResult = RawInputInterop.GetRawInputDeviceInfo(deviceHandle, RawInputInterop.RIDI_DEVICENAME, buffer, ref nameSize);
+
+            if (nameResult == uint.MaxValue)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return Marshal.PtrToStringUni(buffer) ?? string.Empty;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static (string VendorId, string ProductId) ParseVidPid(string deviceName, RawInputInterop.RID_DEVICE_INFO info)
+    {
+        var match = VidPidRegex.Match(deviceName);
+        if (match.Success)
+        {
+            return (match.Groups[1].Value.ToUpperInvariant(), match.Groups[2].Value.ToUpperInvariant());
+        }
+
+        if (info.dwType == RawInputInterop.RIM_TYPEHID)
+        {
+            return ($"{info.info.hid.dwVendorId:X4}", $"{info.info.hid.dwProductId:X4}");
+        }
+
+        return (string.Empty, string.Empty);
+    }
+
+    private static string BuildIdentifier(RawInputDeviceType deviceType, string vendorId, string productId, string deviceName)
+    {
+        if (!string.IsNullOrWhiteSpace(vendorId) || !string.IsNullOrWhiteSpace(productId))
+        {
+            return $"{deviceType switch
+            {
+                RawInputDeviceType.Keyboard => "Keyboard",
+                RawInputDeviceType.Mouse => "Mouse",
+                _ => "Device"
+            }} VID_{vendorId} PID_{productId}";
+        }
+
+        if (!string.IsNullOrWhiteSpace(deviceName))
+        {
+            var shortenedName = deviceName.Replace('#', '\\');
+            return shortenedName.Length <= 80 ? shortenedName : shortenedName[..80] + "...";
+        }
+
+        return "No identifier available";
+    }
+
+    private static string BuildDetails(RawInputInterop.RID_DEVICE_INFO info)
+    {
+        return info.dwType switch
+        {
+            RawInputInterop.RIM_TYPEKEYBOARD => $"Type {info.info.keyboard.dwType}, subtype {info.info.keyboard.dwSubType}, mode {info.info.keyboard.dwKeyboardMode}, total keys {info.info.keyboard.dwNumberOfKeysTotal}, function keys {info.info.keyboard.dwNumberOfFunctionKeys}",
+            RawInputInterop.RIM_TYPEMOUSE => $"{info.info.mouse.dwNumberOfButtons} buttons, sample rate {info.info.mouse.dwSampleRate}, horizontal wheel {info.info.mouse.fHasHorizontalWheel}",
+            RawInputInterop.RIM_TYPEHID => $"Usage page 0x{info.info.hid.usUsagePage:X4}, usage 0x{info.info.hid.usUsage:X4}, version 0x{info.info.hid.dwVersionNumber:X4}",
+            _ => "Unknown raw input device type."
+        };
+    }
+
+    private static RawInputDeviceType ToDeviceType(uint rawType)
+    {
+        return rawType switch
+        {
+            RawInputInterop.RIM_TYPEMOUSE => RawInputDeviceType.Mouse,
+            RawInputInterop.RIM_TYPEKEYBOARD => RawInputDeviceType.Keyboard,
+            RawInputInterop.RIM_TYPEHID => RawInputDeviceType.Hid,
+            _ => RawInputDeviceType.Unknown
+        };
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputDeviceInfo.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputDeviceInfo.cs
@@ -1,0 +1,55 @@
+namespace RawInputPrototype.RawInput;
+
+internal sealed class RawInputDeviceInfo
+{
+    public required nint DeviceHandle { get; init; }
+
+    public required RawInputDeviceType DeviceType { get; init; }
+
+    public required string DeviceName { get; init; }
+
+    public required string VendorId { get; init; }
+
+    public required string ProductId { get; init; }
+
+    public required string Identifier { get; init; }
+
+    public required string Details { get; init; }
+
+    public string DeviceHandleText => RawInputInterop.FormatHandle(DeviceHandle);
+
+    public string DeviceTypeText => DeviceType switch
+    {
+        RawInputDeviceType.Keyboard => "Keyboard",
+        RawInputDeviceType.Mouse => "Mouse",
+        RawInputDeviceType.Hid => "HID",
+        _ => "Unknown"
+    };
+
+    public string DisplayLabel
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(Identifier))
+            {
+                return Identifier;
+            }
+
+            return $"{DeviceTypeText}: {DeviceHandleText}";
+        }
+    }
+
+    public static RawInputDeviceInfo CreateFallback(nint deviceHandle, RawInputDeviceType deviceType, string reason)
+    {
+        return new RawInputDeviceInfo
+        {
+            DeviceHandle = deviceHandle,
+            DeviceType = deviceType,
+            DeviceName = "(device metadata unavailable)",
+            VendorId = string.Empty,
+            ProductId = string.Empty,
+            Identifier = "Metadata unavailable",
+            Details = reason
+        };
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputEvent.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputEvent.cs
@@ -1,0 +1,47 @@
+namespace RawInputPrototype.RawInput;
+
+internal sealed class ParsedRawInputEvent
+{
+    public required DateTime Timestamp { get; init; }
+
+    public required nint DeviceHandle { get; init; }
+
+    public required RawInputDeviceType DeviceType { get; init; }
+
+    public required string InputSource { get; init; }
+
+    public required string Summary { get; init; }
+
+    public string DeviceTypeText => DeviceType switch
+    {
+        RawInputDeviceType.Keyboard => "Keyboard",
+        RawInputDeviceType.Mouse => "Mouse",
+        RawInputDeviceType.Hid => "HID",
+        _ => "Unknown"
+    };
+}
+
+internal sealed class RawInputEvent
+{
+    public required DateTime Timestamp { get; init; }
+
+    public required string EventType { get; init; }
+
+    public required string InputSource { get; init; }
+
+    public required string DeviceHandle { get; init; }
+
+    public required string DeviceLabel { get; init; }
+
+    public required string Summary { get; init; }
+
+    public string TimestampText => Timestamp.ToString("yyyy-MM-dd HH:mm:ss.fff");
+}
+
+internal enum RawInputDeviceType
+{
+    Unknown = -1,
+    Mouse = 0,
+    Keyboard = 1,
+    Hid = 2
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputInterop.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputInterop.cs
@@ -1,0 +1,230 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace RawInputPrototype.RawInput;
+
+internal static class RawInputInterop
+{
+    public const int WM_INPUT = 0x00FF;
+    public const int WM_INPUT_DEVICE_CHANGE = 0x00FE;
+
+    public const int RIM_INPUT = 0;
+    public const int RIM_INPUTSINK = 1;
+
+    public const uint RID_INPUT = 0x10000003;
+    public const uint RIDI_DEVICENAME = 0x20000007;
+    public const uint RIDI_DEVICEINFO = 0x2000000b;
+
+    public const uint RIM_TYPEMOUSE = 0;
+    public const uint RIM_TYPEKEYBOARD = 1;
+    public const uint RIM_TYPEHID = 2;
+
+    public const uint RIDEV_INPUTSINK = 0x00000100;
+    public const uint RIDEV_DEVNOTIFY = 0x00002000;
+
+    public const int GIDC_ARRIVAL = 1;
+    public const int GIDC_REMOVAL = 2;
+
+    public const ushort RI_KEY_BREAK = 0x0001;
+    public const ushort RI_KEY_E0 = 0x0002;
+    public const ushort RI_KEY_E1 = 0x0004;
+
+    public const ushort MOUSE_MOVE_RELATIVE = 0x0000;
+    public const ushort MOUSE_MOVE_ABSOLUTE = 0x0001;
+    public const ushort MOUSE_ATTRIBUTES_CHANGED = 0x0004;
+
+    public const ushort RI_MOUSE_LEFT_BUTTON_DOWN = 0x0001;
+    public const ushort RI_MOUSE_LEFT_BUTTON_UP = 0x0002;
+    public const ushort RI_MOUSE_RIGHT_BUTTON_DOWN = 0x0004;
+    public const ushort RI_MOUSE_RIGHT_BUTTON_UP = 0x0008;
+    public const ushort RI_MOUSE_MIDDLE_BUTTON_DOWN = 0x0010;
+    public const ushort RI_MOUSE_MIDDLE_BUTTON_UP = 0x0020;
+    public const ushort RI_MOUSE_BUTTON_4_DOWN = 0x0040;
+    public const ushort RI_MOUSE_BUTTON_4_UP = 0x0080;
+    public const ushort RI_MOUSE_BUTTON_5_DOWN = 0x0100;
+    public const ushort RI_MOUSE_BUTTON_5_UP = 0x0200;
+    public const ushort RI_MOUSE_WHEEL = 0x0400;
+    public const ushort RI_MOUSE_HWHEEL = 0x0800;
+
+    [DllImport("User32.dll", SetLastError = true)]
+    public static extern bool RegisterRawInputDevices(
+        [MarshalAs(UnmanagedType.LPArray)] RAWINPUTDEVICE[] pRawInputDevices,
+        uint uiNumDevices,
+        uint cbSize);
+
+    [DllImport("User32.dll", SetLastError = true)]
+    public static extern uint GetRawInputData(
+        nint hRawInput,
+        uint uiCommand,
+        nint pData,
+        ref uint pcbSize,
+        uint cbSizeHeader);
+
+    [DllImport("User32.dll", SetLastError = true)]
+    public static extern uint GetRawInputDeviceList(
+        nint pRawInputDeviceList,
+        ref uint puiNumDevices,
+        uint cbSize);
+
+    [DllImport("User32.dll", SetLastError = true, EntryPoint = "GetRawInputDeviceInfoW")]
+    public static extern uint GetRawInputDeviceInfo(
+        nint hDevice,
+        uint uiCommand,
+        nint pData,
+        ref uint pcbSize);
+
+    [DllImport("User32.dll", SetLastError = true, EntryPoint = "GetRawInputDeviceInfoW", CharSet = CharSet.Unicode)]
+    public static extern uint GetRawInputDeviceInfo(
+        nint hDevice,
+        uint uiCommand,
+        ref RID_DEVICE_INFO pData,
+        ref uint pcbSize);
+
+    public static string FormatHandle(nint handle)
+    {
+        return $"0x{handle.ToInt64():X16}";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWINPUTDEVICE
+    {
+        public ushort usUsagePage;
+        public ushort usUsage;
+        public uint dwFlags;
+        public nint hwndTarget;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWINPUTDEVICELIST
+    {
+        public nint hDevice;
+        public uint dwType;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWINPUTHEADER
+    {
+        public uint dwType;
+        public uint dwSize;
+        public nint hDevice;
+        public nint wParam;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWINPUT
+    {
+        public RAWINPUTHEADER header;
+        public RAWINPUTDATA data;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct RAWINPUTDATA
+    {
+        [FieldOffset(0)]
+        public RAWMOUSE mouse;
+
+        [FieldOffset(0)]
+        public RAWKEYBOARD keyboard;
+
+        [FieldOffset(0)]
+        public RAWHID hid;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct RAWMOUSE
+    {
+        [FieldOffset(0)]
+        public ushort usFlags;
+
+        [FieldOffset(4)]
+        public uint ulButtons;
+
+        [FieldOffset(4)]
+        public ushort usButtonFlags;
+
+        [FieldOffset(6)]
+        public ushort usButtonData;
+
+        [FieldOffset(8)]
+        public uint ulRawButtons;
+
+        [FieldOffset(12)]
+        public int lLastX;
+
+        [FieldOffset(16)]
+        public int lLastY;
+
+        [FieldOffset(20)]
+        public uint ulExtraInformation;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWKEYBOARD
+    {
+        public ushort MakeCode;
+        public ushort Flags;
+        public ushort Reserved;
+        public ushort VKey;
+        public uint Message;
+        public uint ExtraInformation;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RAWHID
+    {
+        public uint dwSizeHid;
+        public uint dwCount;
+        public byte bRawData;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RID_DEVICE_INFO
+    {
+        public uint cbSize;
+        public uint dwType;
+        public RID_DEVICE_INFO_UNION info;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct RID_DEVICE_INFO_UNION
+    {
+        [FieldOffset(0)]
+        public RID_DEVICE_INFO_MOUSE mouse;
+
+        [FieldOffset(0)]
+        public RID_DEVICE_INFO_KEYBOARD keyboard;
+
+        [FieldOffset(0)]
+        public RID_DEVICE_INFO_HID hid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RID_DEVICE_INFO_MOUSE
+    {
+        public uint dwId;
+        public uint dwNumberOfButtons;
+        public uint dwSampleRate;
+        public bool fHasHorizontalWheel;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RID_DEVICE_INFO_KEYBOARD
+    {
+        public uint dwType;
+        public uint dwSubType;
+        public uint dwKeyboardMode;
+        public uint dwNumberOfFunctionKeys;
+        public uint dwNumberOfIndicators;
+        public uint dwNumberOfKeysTotal;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RID_DEVICE_INFO_HID
+    {
+        public uint dwVendorId;
+        public uint dwProductId;
+        public uint dwVersionNumber;
+        public ushort usUsagePage;
+        public ushort usUsage;
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputParser.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputParser.cs
@@ -1,0 +1,252 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Windows.Input;
+
+namespace RawInputPrototype.RawInput;
+
+internal static class RawInputParser
+{
+    public static bool TryReadEvent(nint lParam, nint wParam, out ParsedRawInputEvent? parsedEvent, out string? error)
+    {
+        parsedEvent = null;
+        error = null;
+
+        try
+        {
+            var headerSize = (uint)Marshal.SizeOf<RawInputInterop.RAWINPUTHEADER>();
+            uint dataSize = 0;
+
+            var queryResult = RawInputInterop.GetRawInputData(lParam, RawInputInterop.RID_INPUT, nint.Zero, ref dataSize, headerSize);
+            if (queryResult == uint.MaxValue)
+            {
+                error = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                return false;
+            }
+
+            if (dataSize == 0)
+            {
+                error = "GetRawInputData reported an empty payload.";
+                return false;
+            }
+
+            var buffer = Marshal.AllocHGlobal((int)dataSize);
+
+            try
+            {
+                var readResult = RawInputInterop.GetRawInputData(lParam, RawInputInterop.RID_INPUT, buffer, ref dataSize, headerSize);
+                if (readResult == uint.MaxValue)
+                {
+                    error = new Win32Exception(Marshal.GetLastWin32Error()).Message;
+                    return false;
+                }
+
+                var rawInput = Marshal.PtrToStructure<RawInputInterop.RAWINPUT>(buffer);
+
+                parsedEvent = rawInput.header.dwType switch
+                {
+                    RawInputInterop.RIM_TYPEKEYBOARD => ParseKeyboardEvent(rawInput, wParam),
+                    RawInputInterop.RIM_TYPEMOUSE => ParseMouseEvent(rawInput, wParam),
+                    RawInputInterop.RIM_TYPEHID => new ParsedRawInputEvent
+                    {
+                        Timestamp = DateTime.Now,
+                        DeviceHandle = rawInput.header.hDevice,
+                        DeviceType = RawInputDeviceType.Hid,
+                        InputSource = DescribeInputSource(wParam),
+                        Summary = "HID input payload received. This prototype only renders keyboard and mouse details."
+                    },
+                    _ => new ParsedRawInputEvent
+                    {
+                        Timestamp = DateTime.Now,
+                        DeviceHandle = rawInput.header.hDevice,
+                        DeviceType = RawInputDeviceType.Unknown,
+                        InputSource = DescribeInputSource(wParam),
+                        Summary = $"Unsupported raw input type {rawInput.header.dwType}."
+                    }
+                };
+
+                return true;
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
+        }
+        catch (Exception exception)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private static ParsedRawInputEvent ParseKeyboardEvent(RawInputInterop.RAWINPUT rawInput, nint wParam)
+    {
+        var keyboard = rawInput.data.keyboard;
+        var keyState = (keyboard.Flags & RawInputInterop.RI_KEY_BREAK) != 0 ? "Up" : "Down";
+        var keyName = DescribeVirtualKey(keyboard.VKey);
+        var flags = DescribeKeyboardFlags(keyboard.Flags);
+
+        return new ParsedRawInputEvent
+        {
+            Timestamp = DateTime.Now,
+            DeviceHandle = rawInput.header.hDevice,
+            DeviceType = RawInputDeviceType.Keyboard,
+            InputSource = DescribeInputSource(wParam),
+            Summary = $"{keyState} {keyName} (VK 0x{keyboard.VKey:X4}, Make 0x{keyboard.MakeCode:X2}, Flags {flags}, Message 0x{keyboard.Message:X4})"
+        };
+    }
+
+    private static ParsedRawInputEvent ParseMouseEvent(RawInputInterop.RAWINPUT rawInput, nint wParam)
+    {
+        var mouse = rawInput.data.mouse;
+        var fragments = new List<string>();
+
+        if (mouse.lLastX != 0 || mouse.lLastY != 0)
+        {
+            var moveMode = (mouse.usFlags & RawInputInterop.MOUSE_MOVE_ABSOLUTE) != 0 ? "absolute" : "relative";
+            fragments.Add($"{moveMode} move dx={mouse.lLastX}, dy={mouse.lLastY}");
+        }
+
+        AppendMouseButtonFragments(mouse.usButtonFlags, mouse.usButtonData, fragments);
+
+        if ((mouse.usFlags & RawInputInterop.MOUSE_ATTRIBUTES_CHANGED) != 0)
+        {
+            fragments.Add("attributes changed");
+        }
+
+        if (fragments.Count == 0)
+        {
+            fragments.Add("No movement or button delta reported.");
+        }
+
+        return new ParsedRawInputEvent
+        {
+            Timestamp = DateTime.Now,
+            DeviceHandle = rawInput.header.hDevice,
+            DeviceType = RawInputDeviceType.Mouse,
+            InputSource = DescribeInputSource(wParam),
+            Summary = string.Join(", ", fragments)
+        };
+    }
+
+    private static void AppendMouseButtonFragments(ushort buttonFlags, ushort buttonData, List<string> fragments)
+    {
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_LEFT_BUTTON_DOWN) != 0)
+        {
+            fragments.Add("left down");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_LEFT_BUTTON_UP) != 0)
+        {
+            fragments.Add("left up");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_RIGHT_BUTTON_DOWN) != 0)
+        {
+            fragments.Add("right down");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_RIGHT_BUTTON_UP) != 0)
+        {
+            fragments.Add("right up");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_MIDDLE_BUTTON_DOWN) != 0)
+        {
+            fragments.Add("middle down");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_MIDDLE_BUTTON_UP) != 0)
+        {
+            fragments.Add("middle up");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_BUTTON_4_DOWN) != 0)
+        {
+            fragments.Add("button 4 down");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_BUTTON_4_UP) != 0)
+        {
+            fragments.Add("button 4 up");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_BUTTON_5_DOWN) != 0)
+        {
+            fragments.Add("button 5 down");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_BUTTON_5_UP) != 0)
+        {
+            fragments.Add("button 5 up");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_WHEEL) != 0)
+        {
+            fragments.Add($"vertical wheel {unchecked((short)buttonData)}");
+        }
+
+        if ((buttonFlags & RawInputInterop.RI_MOUSE_HWHEEL) != 0)
+        {
+            fragments.Add($"horizontal wheel {unchecked((short)buttonData)}");
+        }
+    }
+
+    private static string DescribeInputSource(nint wParam)
+    {
+        return wParam.ToInt64() switch
+        {
+            RawInputInterop.RIM_INPUT => "Foreground",
+            RawInputInterop.RIM_INPUTSINK => "Background",
+            _ => $"Code {wParam.ToInt64()}"
+        };
+    }
+
+    private static string DescribeVirtualKey(ushort virtualKey)
+    {
+        if (virtualKey is >= 0x30 and <= 0x39 or >= 0x41 and <= 0x5A)
+        {
+            return ((char)virtualKey).ToString();
+        }
+
+        try
+        {
+            var key = KeyInterop.KeyFromVirtualKey(virtualKey);
+            if (key != Key.None)
+            {
+                return key.ToString();
+            }
+        }
+        catch
+        {
+            // Some virtual key codes do not map cleanly into WPF's Key enum.
+        }
+
+        return $"VK 0x{virtualKey:X4}";
+    }
+
+    private static string DescribeKeyboardFlags(ushort flags)
+    {
+        var fragments = new List<string>();
+
+        if ((flags & RawInputInterop.RI_KEY_BREAK) != 0)
+        {
+            fragments.Add("Break");
+        }
+        else
+        {
+            fragments.Add("Make");
+        }
+
+        if ((flags & RawInputInterop.RI_KEY_E0) != 0)
+        {
+            fragments.Add("E0");
+        }
+
+        if ((flags & RawInputInterop.RI_KEY_E1) != 0)
+        {
+            fragments.Add("E1");
+        }
+
+        return string.Join('|', fragments);
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputRegistration.cs
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInput/RawInputRegistration.cs
@@ -1,0 +1,42 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace RawInputPrototype.RawInput;
+
+internal static class RawInputRegistration
+{
+    private const ushort GenericDesktopControlsUsagePage = 0x01;
+    private const ushort MouseUsage = 0x02;
+    private const ushort KeyboardUsage = 0x06;
+
+    public static void RegisterKeyboardAndMouse(nint windowHandle)
+    {
+        var devices = new[]
+        {
+            new RawInputInterop.RAWINPUTDEVICE
+            {
+                usUsagePage = GenericDesktopControlsUsagePage,
+                usUsage = MouseUsage,
+                dwFlags = RawInputInterop.RIDEV_INPUTSINK | RawInputInterop.RIDEV_DEVNOTIFY,
+                hwndTarget = windowHandle
+            },
+            new RawInputInterop.RAWINPUTDEVICE
+            {
+                usUsagePage = GenericDesktopControlsUsagePage,
+                usUsage = KeyboardUsage,
+                dwFlags = RawInputInterop.RIDEV_INPUTSINK | RawInputInterop.RIDEV_DEVNOTIFY,
+                hwndTarget = windowHandle
+            }
+        };
+
+        var registrationSucceeded = RawInputInterop.RegisterRawInputDevices(
+            devices,
+            (uint)devices.Length,
+            (uint)Marshal.SizeOf<RawInputInterop.RAWINPUTDEVICE>());
+
+        if (!registrationSucceeded)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
+}

--- a/prototypes/raw-input-test/RawInputPrototype/RawInputPrototype.csproj
+++ b/prototypes/raw-input-test/RawInputPrototype/RawInputPrototype.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary

Adds a Windows-only Raw Input feasibility prototype under `prototypes/raw-input-test` to test whether Windows can distinguish multiple physical keyboards and mice by source device. The main outcome is a small WPF harness that registers for Raw Input, logs live keyboard and mouse events with device identifiers and metadata, and provides structured documentation for manual feasibility testing without claiming results that have not yet been observed.

## Related Issue

Closes #2

## Scope of Changes

- Added a .NET 8 WPF prototype app that registers for Raw Input and handles `WM_INPUT` and device change messages
- Added parsing and device metadata helpers to log keyboard and mouse events with source handle, identifier, and summary details
- Updated research and prototype documentation with run instructions, manual test steps, evidence to capture, and a feasibility log template

## Validation

Reviewed the implementation for scope, structure, and Windows Raw Input API usage. Manual runtime validation was not completed in this environment because the .NET SDK is not available here and the prototype must be run on Windows hardware to capture real results.

## Documentation Impact

- [ ] No documentation changes required
- [x] Documentation updated in this PR

## Checklist

- [x] The change is focused and within issue scope
- [x] Relevant docs were updated where needed
- [x] Validation appropriate to the change was completed
- [x] No unrelated implementation or cleanup was bundled into this PR