### PR TITLE
[#6, #7, #8] - add windows display switcher abstraction, decision engine with tests and device registry with zone mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,27 @@ Typical target scenario:
 
 ## Current Status
 
-The repository is currently in foundation and feasibility mode. The immediate focus is to:
+The repository now has both:
 
-- validate whether Windows can reliably distinguish physical keyboards and mice
-- capture which device metadata appears usable for later persistence and reconciliation
-- validate whether display profiles can be switched programmatically on the target hardware
-- document architecture, risks, conventions, and evaluation criteria before implementation begins
+- feasibility prototypes under `prototypes/`
+- an initial production MVP slice under `src/` and `tests/`
 
-Early Raw Input feasibility work on the current test setup is promising: multiple physical keyboards and mice could be distinguished at runtime, but persisted device identity still requires a stronger composite strategy than raw handles alone.
+What is now implemented:
 
-No application logic, GUI implementation, or production switching pipeline is being claimed as complete at this stage.
+- a platform-neutral core model for runtime devices, persisted device identities, zones, display profiles, runtime state, decisions, and execution results
+- a JSON-backed device registry with zone/profile resolution
+- a rule-based decision engine v1 with explicit allowed, blocked, and no-op outcomes
+- an orchestration path from runtime observation to optional display execution
+- an initial Windows display switcher abstraction backed by `SetDisplayConfig` database-topology calls
+
+What remains intentionally incomplete:
+
+- Raw Input integration into the production pipeline
+- WPF application shell and configuration UI
+- richer persistence/versioning support
+- hardware-proven robust display switching across all target setups
+
+Early Raw Input feasibility work on the current test setup remains promising: multiple physical keyboards and mice could be distinguished at runtime, but persisted device identity still benefits from a stronger composite strategy than raw handles alone.
 
 ## Planned Architecture Summary
 
@@ -80,8 +91,8 @@ High-level intent:
 
 - `docs/` holds architecture, planning, evaluation, and research material.
 - `prototypes/` holds scoped feasibility spikes before production code is committed.
-- `src/` will later contain the production application and supporting libraries.
-- `tests/` will hold automated tests and supporting test assets where appropriate.
+- `src/` contains the current production libraries for core logic and infrastructure adapters.
+- `tests/` contains automated tests for registry resolution, decision logic, orchestration, and JSON persistence.
 
 ## Technology Direction
 
@@ -98,9 +109,7 @@ Some of these choices are still documented as provisional where feasibility evid
 
 Near-term work should stay focused on:
 
-- feasibility prototypes
-- documentation and design clarification
-- evaluation planning
-- repository hygiene and workflow discipline
-
-Implementation of Raw Input handling, display switching logic, GUI screens, and the decision engine belongs to later issues once the feasibility work has produced evidence.
+- wiring real Raw Input observations into the production orchestration layer
+- validating Windows switching behaviour on target hardware and refining the execution strategy where needed
+- adding the WPF shell, configuration flows, and runtime diagnostics views
+- continuing to document behaviour, risks, and evaluation findings as the MVP matures

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -105,3 +105,11 @@ This file acts as a lightweight ADR log for early project decisions. Entries may
 - Decision: Zones will carry simple precedence information and profile references, while switching rules such as cooldowns, lock behaviour, and minimum confidence will live in separate policy objects.
 - Rationale: Embedding all rule behaviour directly into zone records would blur configuration boundaries, duplicate policy, and make global behaviour harder to reason about.
 - Consequence: Later MVP logic can stay simple while still supporting future expansion to weighted or more advanced rules without reshaping the basic zone model.
+
+## ADR-014: Use implementation hints to translate logical profiles into the first Windows switching path
+
+- Status: Accepted
+- Date: 2026-04-01
+- Decision: `DisplayProfile` remains a logical domain concept, while the initial Windows switcher may use optional implementation hints such as `windows.topology` to map a logical profile onto `SetDisplayConfig` database-topology actions.
+- Rationale: The current architecture intentionally keeps profiles logical, but the first Windows execution path can only safely apply a small set of topology-based actions. Implementation hints let the infrastructure bridge that gap without leaking Windows API details into the core model.
+- Consequence: Zone-specific profiles such as `DeskOnly` or `LivingRoomOnly` can exist in the domain immediately, while Windows execution stays honest about which profiles are directly supported and which require explicit mapping or later refinement.

--- a/input-aware-display-switcher.sln
+++ b/input-aware-display-switcher.sln
@@ -1,0 +1,67 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "prototypes", "prototypes", "{E54166BF-D5A5-D108-1244-AA6816D2859D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{AD90D41B-6A41-4EA8-8EBA-3E3F0C8220C6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{758C6E55-36F5-4DC0-A6DA-37AE205C5BB8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "display-switch-test", "display-switch-test", "{5A738856-83D8-26A3-3804-92ED932662A8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DisplaySwitchPrototype", "prototypes\display-switch-test\DisplaySwitchPrototype\DisplaySwitchPrototype.csproj", "{3FAD2331-6BF7-48EA-95F0-792B61B076EC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "raw-input-test", "raw-input-test", "{ACC02A46-4208-352C-DC2B-0A260524F489}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RawInputPrototype", "prototypes\raw-input-test\RawInputPrototype\RawInputPrototype.csproj", "{AB69C5BF-6600-DF8E-8D32-4BC67C92064B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputAwareDisplaySwitcher.Core", "src\InputAwareDisplaySwitcher.Core\InputAwareDisplaySwitcher.Core.csproj", "{5BA86410-159E-4A9A-912C-27982193C8EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputAwareDisplaySwitcher.Infrastructure", "src\InputAwareDisplaySwitcher.Infrastructure\InputAwareDisplaySwitcher.Infrastructure.csproj", "{71C4B4E0-7449-4963-A5B4-CDF76B194D60}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InputAwareDisplaySwitcher.Tests", "tests\InputAwareDisplaySwitcher.Tests\InputAwareDisplaySwitcher.Tests.csproj", "{A1481A56-50E9-4FEF-A40D-A85A3D58F14F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5BA86410-159E-4A9A-912C-27982193C8EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BA86410-159E-4A9A-912C-27982193C8EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BA86410-159E-4A9A-912C-27982193C8EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BA86410-159E-4A9A-912C-27982193C8EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{71C4B4E0-7449-4963-A5B4-CDF76B194D60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{71C4B4E0-7449-4963-A5B4-CDF76B194D60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{71C4B4E0-7449-4963-A5B4-CDF76B194D60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{71C4B4E0-7449-4963-A5B4-CDF76B194D60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1481A56-50E9-4FEF-A40D-A85A3D58F14F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1481A56-50E9-4FEF-A40D-A85A3D58F14F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1481A56-50E9-4FEF-A40D-A85A3D58F14F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1481A56-50E9-4FEF-A40D-A85A3D58F14F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3FAD2331-6BF7-48EA-95F0-792B61B076EC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3FAD2331-6BF7-48EA-95F0-792B61B076EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3FAD2331-6BF7-48EA-95F0-792B61B076EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3FAD2331-6BF7-48EA-95F0-792B61B076EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB69C5BF-6600-DF8E-8D32-4BC67C92064B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB69C5BF-6600-DF8E-8D32-4BC67C92064B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB69C5BF-6600-DF8E-8D32-4BC67C92064B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB69C5BF-6600-DF8E-8D32-4BC67C92064B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5BA86410-159E-4A9A-912C-27982193C8EA} = {AD90D41B-6A41-4EA8-8EBA-3E3F0C8220C6}
+		{71C4B4E0-7449-4963-A5B4-CDF76B194D60} = {AD90D41B-6A41-4EA8-8EBA-3E3F0C8220C6}
+		{A1481A56-50E9-4FEF-A40D-A85A3D58F14F} = {758C6E55-36F5-4DC0-A6DA-37AE205C5BB8}
+		{5A738856-83D8-26A3-3804-92ED932662A8} = {E54166BF-D5A5-D108-1244-AA6816D2859D}
+		{3FAD2331-6BF7-48EA-95F0-792B61B076EC} = {5A738856-83D8-26A3-3804-92ED932662A8}
+		{ACC02A46-4208-352C-DC2B-0A260524F489} = {E54166BF-D5A5-D108-1244-AA6816D2859D}
+		{AB69C5BF-6600-DF8E-8D32-4BC67C92064B} = {ACC02A46-4208-352C-DC2B-0A260524F489}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6BC8E041-9716-4480-A518-B9D732528EDE}
+	EndGlobalSection
+EndGlobal

--- a/src/InputAwareDisplaySwitcher.Core/Abstractions/IDisplaySwitcher.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Abstractions/IDisplaySwitcher.cs
@@ -1,0 +1,9 @@
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Abstractions;
+
+public interface IDisplaySwitcher
+{
+    Task<SwitchExecutionResult> ApplyAsync(DisplayProfile profile, CancellationToken cancellationToken = default);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DecisionEngineV1.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DecisionEngineV1.cs
@@ -1,0 +1,100 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class DecisionEngineV1 : IDecisionEngine
+{
+    public SwitchDecision Evaluate(DecisionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var resolution = request.Resolution;
+        var now = request.EvaluatedAtUtc;
+
+        switch (resolution.Status)
+        {
+            case DeviceRegistryResolutionStatus.UnknownDevice:
+                return Blocked(request, SwitchDecisionReason.UnknownDevice, resolution.Message ?? "The device is unknown.");
+            case DeviceRegistryResolutionStatus.DeviceDisabled:
+                return Blocked(request, SwitchDecisionReason.DisabledDevice, resolution.Message ?? "The matched device is disabled.");
+            case DeviceRegistryResolutionStatus.UnmappedZone:
+                return Blocked(request, SwitchDecisionReason.UnmappedDevice, resolution.Message ?? "The matched device is not mapped to a zone.");
+            case DeviceRegistryResolutionStatus.ZoneDisabled:
+                return Blocked(request, SwitchDecisionReason.DisabledZone, resolution.Message ?? "The resolved zone is disabled.");
+            case DeviceRegistryResolutionStatus.ProfileUnavailable:
+                return Blocked(request, SwitchDecisionReason.MissingDisplayProfile, resolution.Message ?? "The resolved display profile is unavailable.");
+        }
+
+        if (request.Policy.ManualLockStopsSwitching && request.RuntimeState.IsManualSwitchingLocked)
+        {
+            return Blocked(request, SwitchDecisionReason.ManualLockActive, "Automatic switching is currently locked.");
+        }
+
+        if (request.Policy.Cooldown > TimeSpan.Zero && request.RuntimeState.LastSwitchAtUtc.HasValue)
+        {
+            var cooldownEndsAtUtc = request.RuntimeState.LastSwitchAtUtc.Value.Add(request.Policy.Cooldown);
+            if (cooldownEndsAtUtc > now)
+            {
+                return new SwitchDecision
+                {
+                    Status = SwitchDecisionStatus.Blocked,
+                    Reason = SwitchDecisionReason.CooldownActive,
+                    Message = $"Cooldown is active until {cooldownEndsAtUtc:O}.",
+                    EvaluatedAtUtc = now,
+                    MatchedDeviceId = resolution.MatchedDevice?.DeviceId,
+                    TargetZoneId = resolution.Zone?.ZoneId,
+                    TargetDisplayProfileId = resolution.TargetProfile?.DisplayProfileId,
+                    CooldownEndsAtUtc = cooldownEndsAtUtc
+                };
+            }
+        }
+
+        var sameZone = !string.IsNullOrWhiteSpace(request.RuntimeState.CurrentZoneId)
+            && string.Equals(request.RuntimeState.CurrentZoneId, resolution.Zone?.ZoneId, StringComparison.OrdinalIgnoreCase);
+        var sameProfile = !string.IsNullOrWhiteSpace(request.RuntimeState.CurrentDisplayProfileId)
+            && string.Equals(request.RuntimeState.CurrentDisplayProfileId, resolution.TargetProfile?.DisplayProfileId, StringComparison.OrdinalIgnoreCase);
+
+        var sameTargetAlreadyActive = sameProfile
+            || (sameZone && string.IsNullOrWhiteSpace(request.RuntimeState.CurrentDisplayProfileId));
+
+        if (!request.Policy.AllowSameProfileRefresh && sameTargetAlreadyActive)
+        {
+            return new SwitchDecision
+            {
+                Status = SwitchDecisionStatus.NoAction,
+                Reason = SwitchDecisionReason.AlreadyActive,
+                Message = "The resolved zone/profile is already active, so no switch is needed.",
+                EvaluatedAtUtc = now,
+                MatchedDeviceId = resolution.MatchedDevice?.DeviceId,
+                TargetZoneId = resolution.Zone?.ZoneId,
+                TargetDisplayProfileId = resolution.TargetProfile?.DisplayProfileId
+            };
+        }
+
+        return new SwitchDecision
+        {
+            Status = SwitchDecisionStatus.Allowed,
+            Reason = SwitchDecisionReason.Allowed,
+            Message = "Switching is allowed for the resolved device, zone, and display profile.",
+            EvaluatedAtUtc = now,
+            MatchedDeviceId = resolution.MatchedDevice?.DeviceId,
+            TargetZoneId = resolution.Zone?.ZoneId,
+            TargetDisplayProfileId = resolution.TargetProfile?.DisplayProfileId
+        };
+    }
+
+    private static SwitchDecision Blocked(DecisionRequest request, SwitchDecisionReason reason, string message)
+    {
+        return new SwitchDecision
+        {
+            Status = SwitchDecisionStatus.Blocked,
+            Reason = reason,
+            Message = message,
+            EvaluatedAtUtc = request.EvaluatedAtUtc,
+            MatchedDeviceId = request.Resolution.MatchedDevice?.DeviceId,
+            TargetZoneId = request.Resolution.Zone?.ZoneId,
+            TargetDisplayProfileId = request.Resolution.TargetProfile?.DisplayProfileId
+        };
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DeviceRegistryService.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DeviceRegistryService.cs
@@ -1,0 +1,207 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class DeviceRegistryService
+{
+    private readonly IDeviceRegistryStore _store;
+
+    public DeviceRegistryService(IDeviceRegistryStore store)
+    {
+        _store = store;
+    }
+
+    public Task<DeviceRegistrySnapshot> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        return _store.LoadAsync(cancellationToken);
+    }
+
+    public Task SaveAsync(DeviceRegistrySnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        return _store.SaveAsync(snapshot, cancellationToken);
+    }
+
+    public async Task RegisterOrUpdateDeviceAsync(PersistedDeviceIdentity device, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        var snapshot = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        Upsert(snapshot.Devices, device, existing => existing.DeviceId, incoming => incoming.DeviceId);
+        await _store.SaveAsync(snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RegisterOrUpdateZoneAsync(ZoneDefinition zone, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(zone);
+
+        var snapshot = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        Upsert(snapshot.Zones, zone, existing => existing.ZoneId, incoming => incoming.ZoneId);
+        await _store.SaveAsync(snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RegisterOrUpdateDisplayProfileAsync(DisplayProfile profile, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var snapshot = await _store.LoadAsync(cancellationToken).ConfigureAwait(false);
+        Upsert(snapshot.DisplayProfiles, profile, existing => existing.DisplayProfileId, incoming => incoming.DisplayProfileId);
+        await _store.SaveAsync(snapshot, cancellationToken).ConfigureAwait(false);
+    }
+
+    public DeviceRegistryResolution Resolve(RuntimeDeviceObservation observation, DeviceRegistrySnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(observation);
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var candidateKeys = observation.GetCandidatePersistenceKeys();
+        var matchedDevice = snapshot.Devices.FirstOrDefault(device => GetPersistenceKeys(device)
+            .Intersect(candidateKeys, StringComparer.OrdinalIgnoreCase)
+            .Any());
+
+        if (matchedDevice is null)
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.UnknownDevice,
+                Observation = observation,
+                Message = $"No persisted device mapping matched runtime device '{observation.FriendlyName ?? observation.SessionDeviceId}'."
+            };
+        }
+
+        var matchedKey = GetPersistenceKeys(matchedDevice)
+            .Intersect(candidateKeys, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+
+        if (!matchedDevice.IsEnabled)
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.DeviceDisabled,
+                Observation = observation,
+                MatchedDevice = matchedDevice,
+                MatchedByPersistenceKey = matchedKey,
+                Message = $"Persisted device '{matchedDevice.FriendlyName}' is disabled."
+            };
+        }
+
+        if (string.IsNullOrWhiteSpace(matchedDevice.AssignedZoneId))
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.UnmappedZone,
+                Observation = observation,
+                MatchedDevice = matchedDevice,
+                MatchedByPersistenceKey = matchedKey,
+                Message = $"Persisted device '{matchedDevice.FriendlyName}' is not assigned to a zone."
+            };
+        }
+
+        var zone = snapshot.FindZone(matchedDevice.AssignedZoneId);
+        if (zone is null)
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.UnmappedZone,
+                Observation = observation,
+                MatchedDevice = matchedDevice,
+                MatchedByPersistenceKey = matchedKey,
+                Message = $"Device '{matchedDevice.FriendlyName}' points to unknown zone '{matchedDevice.AssignedZoneId}'."
+            };
+        }
+
+        if (!zone.IsEnabled)
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.ZoneDisabled,
+                Observation = observation,
+                MatchedDevice = matchedDevice,
+                Zone = zone,
+                MatchedByPersistenceKey = matchedKey,
+                Message = $"Zone '{zone.Name}' is disabled."
+            };
+        }
+
+        var profile = snapshot.FindProfile(zone.PreferredDisplayProfileId);
+        if (profile is null || !profile.IsEnabled)
+        {
+            return new DeviceRegistryResolution
+            {
+                Status = DeviceRegistryResolutionStatus.ProfileUnavailable,
+                Observation = observation,
+                MatchedDevice = matchedDevice,
+                Zone = zone,
+                MatchedByPersistenceKey = matchedKey,
+                Message = $"Zone '{zone.Name}' does not resolve to an enabled display profile."
+            };
+        }
+
+        return new DeviceRegistryResolution
+        {
+            Status = DeviceRegistryResolutionStatus.Resolved,
+            Observation = observation,
+            MatchedDevice = matchedDevice,
+            Zone = zone,
+            TargetProfile = profile,
+            MatchedByPersistenceKey = matchedKey,
+            Message = $"Device '{matchedDevice.FriendlyName}' resolved to zone '{zone.Name}' and profile '{profile.Name}'."
+        };
+    }
+
+    private static IEnumerable<string> GetPersistenceKeys(PersistedDeviceIdentity device)
+    {
+        if (!string.IsNullOrWhiteSpace(device.PreferredPersistenceKey))
+        {
+            yield return device.PreferredPersistenceKey;
+        }
+
+        var evidence = device.IdentityEvidence;
+
+        var instanceKey = RuntimeDeviceObservation.BuildInstanceKey(evidence.InstanceId);
+        if (!string.IsNullOrWhiteSpace(instanceKey))
+        {
+            yield return instanceKey;
+        }
+
+        var pathKey = RuntimeDeviceObservation.BuildPathKey(evidence.NormalizedDevicePath);
+        if (!string.IsNullOrWhiteSpace(pathKey))
+        {
+            yield return pathKey;
+        }
+
+        var rawPathKey = RuntimeDeviceObservation.BuildRawPathKey(evidence.RawDevicePath);
+        if (!string.IsNullOrWhiteSpace(rawPathKey))
+        {
+            yield return rawPathKey;
+        }
+
+        var vidPidKey = RuntimeDeviceObservation.BuildVidPidKey(device.DeviceKind, evidence.VendorId, evidence.ProductId);
+        if (!string.IsNullOrWhiteSpace(vidPidKey))
+        {
+            yield return vidPidKey;
+        }
+    }
+
+    private static void Upsert<T>(
+        IList<T> items,
+        T incoming,
+        Func<T, string> existingKeySelector,
+        Func<T, string> incomingKeySelector)
+    {
+        var incomingKey = incomingKeySelector(incoming);
+        var existingIndex = items
+            .Select((item, index) => new { item, index })
+            .FirstOrDefault(entry => string.Equals(existingKeySelector(entry.item), incomingKey, StringComparison.OrdinalIgnoreCase))
+            ?.index;
+
+        if (existingIndex.HasValue)
+        {
+            items[existingIndex.Value] = incoming;
+            return;
+        }
+
+        items.Add(incoming);
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/IDecisionEngine.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/IDecisionEngine.cs
@@ -1,0 +1,8 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public interface IDecisionEngine
+{
+    SwitchDecision Evaluate(DecisionRequest request);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/IDeviceRegistryStore.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/IDeviceRegistryStore.cs
@@ -1,0 +1,10 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public interface IDeviceRegistryStore
+{
+    Task<DeviceRegistrySnapshot> LoadAsync(CancellationToken cancellationToken = default);
+
+    Task SaveAsync(DeviceRegistrySnapshot snapshot, CancellationToken cancellationToken = default);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/SwitchingOrchestrator.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/SwitchingOrchestrator.cs
@@ -1,0 +1,64 @@
+using InputAwareDisplaySwitcher.Core.Abstractions;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class SwitchingOrchestrator
+{
+    private readonly DeviceRegistryService _deviceRegistryService;
+    private readonly IDecisionEngine _decisionEngine;
+    private readonly IDisplaySwitcher _displaySwitcher;
+
+    public SwitchingOrchestrator(
+        DeviceRegistryService deviceRegistryService,
+        IDecisionEngine decisionEngine,
+        IDisplaySwitcher displaySwitcher)
+    {
+        _deviceRegistryService = deviceRegistryService;
+        _decisionEngine = decisionEngine;
+        _displaySwitcher = displaySwitcher;
+    }
+
+    public async Task<SwitchingOutcome> ProcessAsync(
+        RuntimeDeviceObservation observation,
+        ApplicationRuntimeState runtimeState,
+        SwitchingPolicy policy,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(observation);
+        ArgumentNullException.ThrowIfNull(runtimeState);
+        ArgumentNullException.ThrowIfNull(policy);
+
+        var snapshot = await _deviceRegistryService.LoadAsync(cancellationToken).ConfigureAwait(false);
+        var resolution = _deviceRegistryService.Resolve(observation, snapshot);
+
+        var decision = _decisionEngine.Evaluate(new DecisionRequest
+        {
+            Observation = observation,
+            Resolution = resolution,
+            RuntimeState = runtimeState,
+            Policy = policy,
+            EvaluatedAtUtc = observation.ObservedAtUtc
+        });
+
+        var executionResult = SwitchExecutionResult.NotAttempted(
+            decision.TargetDisplayProfileId,
+            "No display switch was attempted.");
+
+        if (decision.ShouldSwitch && resolution.TargetProfile is not null)
+        {
+            executionResult = await _displaySwitcher
+                .ApplyAsync(resolution.TargetProfile, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return new SwitchingOutcome
+        {
+            Observation = observation,
+            Resolution = resolution,
+            Decision = decision,
+            ExecutionResult = executionResult
+        };
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/SwitchingOutcome.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/SwitchingOutcome.cs
@@ -1,0 +1,15 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed record SwitchingOutcome
+{
+    public required RuntimeDeviceObservation Observation { get; init; }
+
+    public required DeviceRegistryResolution Resolution { get; init; }
+
+    public required SwitchDecision Decision { get; init; }
+
+    public required SwitchExecutionResult ExecutionResult { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceIdentityEvidence.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceIdentityEvidence.cs
@@ -1,0 +1,20 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public sealed record DeviceIdentityEvidence
+{
+    public string? RawDevicePath { get; init; }
+
+    public string? NormalizedDevicePath { get; init; }
+
+    public string? InstanceId { get; init; }
+
+    public string? VendorId { get; init; }
+
+    public string? ProductId { get; init; }
+
+    public string? FriendlyName { get; init; }
+
+    public string? Manufacturer { get; init; }
+
+    public string? EnumeratorName { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceKind.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceKind.cs
@@ -1,0 +1,9 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public enum DeviceKind
+{
+    Unknown = 0,
+    Keyboard = 1,
+    Mouse = 2,
+    PointingDevice = 3
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistryResolution.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistryResolution.cs
@@ -1,0 +1,23 @@
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public sealed record DeviceRegistryResolution
+{
+    public required DeviceRegistryResolutionStatus Status { get; init; }
+
+    public required RuntimeDeviceObservation Observation { get; init; }
+
+    public PersistedDeviceIdentity? MatchedDevice { get; init; }
+
+    public ZoneDefinition? Zone { get; init; }
+
+    public DisplayProfile? TargetProfile { get; init; }
+
+    public string? MatchedByPersistenceKey { get; init; }
+
+    public string? Message { get; init; }
+
+    public bool HasResolvedTarget => Status == DeviceRegistryResolutionStatus.Resolved;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistryResolutionStatus.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistryResolutionStatus.cs
@@ -1,0 +1,11 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public enum DeviceRegistryResolutionStatus
+{
+    UnknownDevice = 0,
+    DeviceDisabled = 1,
+    UnmappedZone = 2,
+    ZoneDisabled = 3,
+    ProfileUnavailable = 4,
+    Resolved = 5
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistrySnapshot.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/DeviceRegistrySnapshot.cs
@@ -1,0 +1,27 @@
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public sealed record DeviceRegistrySnapshot
+{
+    public List<PersistedDeviceIdentity> Devices { get; init; } = [];
+
+    public List<ZoneDefinition> Zones { get; init; } = [];
+
+    public List<DisplayProfile> DisplayProfiles { get; init; } = [];
+
+    public ZoneDefinition? FindZone(string? zoneId)
+    {
+        return string.IsNullOrWhiteSpace(zoneId)
+            ? null
+            : Zones.FirstOrDefault(zone => string.Equals(zone.ZoneId, zoneId, StringComparison.OrdinalIgnoreCase));
+    }
+
+    public DisplayProfile? FindProfile(string? profileId)
+    {
+        return string.IsNullOrWhiteSpace(profileId)
+            ? null
+            : DisplayProfiles.FirstOrDefault(profile => string.Equals(profile.DisplayProfileId, profileId, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/PersistedDeviceIdentity.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/PersistedDeviceIdentity.cs
@@ -1,0 +1,22 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public sealed record PersistedDeviceIdentity
+{
+    public required string DeviceId { get; init; }
+
+    public required string FriendlyName { get; init; }
+
+    public DeviceKind DeviceKind { get; init; } = DeviceKind.Unknown;
+
+    public required string PreferredPersistenceKey { get; init; }
+
+    public DeviceIdentityEvidence IdentityEvidence { get; init; } = new();
+
+    public string? AssignedZoneId { get; init; }
+
+    public Dictionary<string, string> Metadata { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public DateTimeOffset? LastConfirmedAtUtc { get; init; }
+
+    public bool IsEnabled { get; init; } = true;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Devices/RuntimeDeviceObservation.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Devices/RuntimeDeviceObservation.cs
@@ -1,0 +1,99 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+public sealed record RuntimeDeviceObservation
+{
+    public required string SessionDeviceId { get; init; }
+
+    public DeviceKind DeviceKind { get; init; } = DeviceKind.Unknown;
+
+    public string? RawDevicePath { get; init; }
+
+    public string? NormalizedDevicePath { get; init; }
+
+    public string? InstanceId { get; init; }
+
+    public string? VendorId { get; init; }
+
+    public string? ProductId { get; init; }
+
+    public string? FriendlyName { get; init; }
+
+    public DateTimeOffset ObservedAtUtc { get; init; }
+
+    public DateTimeOffset? LastSeenAtUtc { get; init; }
+
+    public bool IsAvailableThisSession { get; init; } = true;
+
+    public IReadOnlyList<string> GetCandidatePersistenceKeys()
+    {
+        var keys = new List<string>();
+
+        AddIfPresent(keys, BuildInstanceKey(InstanceId));
+        AddIfPresent(keys, BuildPathKey(NormalizedDevicePath));
+        AddIfPresent(keys, BuildRawPathKey(RawDevicePath));
+        AddIfPresent(keys, BuildVidPidKey(DeviceKind, VendorId, ProductId));
+        AddIfPresent(keys, BuildSessionKey(SessionDeviceId));
+
+        return keys
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    internal static string? BuildInstanceKey(string? instanceId)
+    {
+        return string.IsNullOrWhiteSpace(instanceId)
+            ? null
+            : $"instance:{instanceId}";
+    }
+
+    internal static string? BuildPathKey(string? normalizedDevicePath)
+    {
+        return string.IsNullOrWhiteSpace(normalizedDevicePath)
+            ? null
+            : $"path:{normalizedDevicePath}";
+    }
+
+    internal static string? BuildRawPathKey(string? rawDevicePath)
+    {
+        return string.IsNullOrWhiteSpace(rawDevicePath)
+            ? null
+            : $"rawpath:{rawDevicePath}";
+    }
+
+    internal static string? BuildSessionKey(string? sessionDeviceId)
+    {
+        return string.IsNullOrWhiteSpace(sessionDeviceId)
+            ? null
+            : $"session:{sessionDeviceId}";
+    }
+
+    internal static string? BuildVidPidKey(DeviceKind deviceKind, string? vendorId, string? productId)
+    {
+        if (string.IsNullOrWhiteSpace(vendorId) && string.IsNullOrWhiteSpace(productId))
+        {
+            return null;
+        }
+
+        var parts = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(vendorId))
+        {
+            parts.Add($"VID_{vendorId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(productId))
+        {
+            parts.Add($"PID_{productId}");
+        }
+
+        return $"{deviceKind.ToString().ToLowerInvariant()}:{string.Join("/", parts)}";
+    }
+
+    private static void AddIfPresent(ICollection<string> keys, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            keys.Add(value);
+        }
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Profiles/DisplayProfile.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Profiles/DisplayProfile.cs
@@ -1,0 +1,16 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Profiles;
+
+public sealed record DisplayProfile
+{
+    public required string DisplayProfileId { get; init; }
+
+    public required string Name { get; init; }
+
+    public DisplayProfileIntentKind IntentKind { get; init; } = DisplayProfileIntentKind.Unknown;
+
+    public string? Description { get; init; }
+
+    public Dictionary<string, string> ImplementationHints { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public bool IsEnabled { get; init; } = true;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Profiles/DisplayProfileIntentKind.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Profiles/DisplayProfileIntentKind.cs
@@ -1,0 +1,13 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Profiles;
+
+public enum DisplayProfileIntentKind
+{
+    Unknown = 0,
+    DeskOnly = 1,
+    LivingRoomOnly = 2,
+    InternalOnly = 3,
+    ExternalOnly = 4,
+    Extend = 5,
+    Clone = 6,
+    SafeRestore = 7
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/ApplicationRuntimeState.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/ApplicationRuntimeState.cs
@@ -1,0 +1,14 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public sealed record ApplicationRuntimeState
+{
+    public string? CurrentZoneId { get; init; }
+
+    public string? CurrentDisplayProfileId { get; init; }
+
+    public DateTimeOffset? LastSwitchAtUtc { get; init; }
+
+    public bool IsManualSwitchingLocked { get; init; }
+
+    public string? LastMatchedDeviceId { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/DecisionRequest.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/DecisionRequest.cs
@@ -1,0 +1,16 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public sealed record DecisionRequest
+{
+    public required RuntimeDeviceObservation Observation { get; init; }
+
+    public required DeviceRegistryResolution Resolution { get; init; }
+
+    public required ApplicationRuntimeState RuntimeState { get; init; }
+
+    public required SwitchingPolicy Policy { get; init; }
+
+    public DateTimeOffset EvaluatedAtUtc { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecision.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecision.cs
@@ -1,0 +1,22 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public sealed record SwitchDecision
+{
+    public required SwitchDecisionStatus Status { get; init; }
+
+    public required SwitchDecisionReason Reason { get; init; }
+
+    public required string Message { get; init; }
+
+    public required DateTimeOffset EvaluatedAtUtc { get; init; }
+
+    public string? MatchedDeviceId { get; init; }
+
+    public string? TargetZoneId { get; init; }
+
+    public string? TargetDisplayProfileId { get; init; }
+
+    public DateTimeOffset? CooldownEndsAtUtc { get; init; }
+
+    public bool ShouldSwitch => Status == SwitchDecisionStatus.Allowed;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionReason.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionReason.cs
@@ -1,0 +1,14 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public enum SwitchDecisionReason
+{
+    Allowed = 0,
+    UnknownDevice = 1,
+    DisabledDevice = 2,
+    UnmappedDevice = 3,
+    DisabledZone = 4,
+    MissingDisplayProfile = 5,
+    ManualLockActive = 6,
+    CooldownActive = 7,
+    AlreadyActive = 8
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionStatus.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionStatus.cs
@@ -1,0 +1,8 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public enum SwitchDecisionStatus
+{
+    Allowed = 0,
+    Blocked = 1,
+    NoAction = 2
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchExecutionResult.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchExecutionResult.cs
@@ -1,0 +1,64 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public sealed record SwitchExecutionResult
+{
+    public string? DisplayProfileId { get; init; }
+
+    public required SwitchExecutionStatus Status { get; init; }
+
+    public required string ExecutionPath { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public int? ErrorCode { get; init; }
+
+    public DateTimeOffset RecordedAtUtc { get; init; } = DateTimeOffset.UtcNow;
+
+    public bool WasAttempted => Status is SwitchExecutionStatus.Succeeded or SwitchExecutionStatus.Failed;
+
+    public bool Success => Status == SwitchExecutionStatus.Succeeded;
+
+    public static SwitchExecutionResult NotAttempted(string? displayProfileId, string message)
+    {
+        return new SwitchExecutionResult
+        {
+            DisplayProfileId = displayProfileId,
+            Status = SwitchExecutionStatus.NotAttempted,
+            ExecutionPath = "Not attempted",
+            ErrorMessage = message
+        };
+    }
+
+    public static SwitchExecutionResult Unsupported(string? displayProfileId, string executionPath, string message)
+    {
+        return new SwitchExecutionResult
+        {
+            DisplayProfileId = displayProfileId,
+            Status = SwitchExecutionStatus.Unsupported,
+            ExecutionPath = executionPath,
+            ErrorMessage = message
+        };
+    }
+
+    public static SwitchExecutionResult Failure(string? displayProfileId, string executionPath, string message, int? errorCode = null)
+    {
+        return new SwitchExecutionResult
+        {
+            DisplayProfileId = displayProfileId,
+            Status = SwitchExecutionStatus.Failed,
+            ExecutionPath = executionPath,
+            ErrorMessage = message,
+            ErrorCode = errorCode
+        };
+    }
+
+    public static SwitchExecutionResult Succeeded(string? displayProfileId, string executionPath)
+    {
+        return new SwitchExecutionResult
+        {
+            DisplayProfileId = displayProfileId,
+            Status = SwitchExecutionStatus.Succeeded,
+            ExecutionPath = executionPath
+        };
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchExecutionStatus.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchExecutionStatus.cs
@@ -1,0 +1,9 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public enum SwitchExecutionStatus
+{
+    NotAttempted = 0,
+    Succeeded = 1,
+    Failed = 2,
+    Unsupported = 3
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchingPolicy.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchingPolicy.cs
@@ -1,0 +1,10 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public sealed record SwitchingPolicy
+{
+    public TimeSpan Cooldown { get; init; } = TimeSpan.FromSeconds(30);
+
+    public bool ManualLockStopsSwitching { get; init; } = true;
+
+    public bool AllowSameProfileRefresh { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Zones/ZoneDefinition.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Zones/ZoneDefinition.cs
@@ -1,0 +1,16 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+public sealed record ZoneDefinition
+{
+    public required string ZoneId { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string PreferredDisplayProfileId { get; init; }
+
+    public int Priority { get; init; }
+
+    public bool IsEnabled { get; init; } = true;
+
+    public string? Description { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/InputAwareDisplaySwitcher.Core.csproj
+++ b/src/InputAwareDisplaySwitcher.Core/InputAwareDisplaySwitcher.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Configuration/JsonDeviceRegistryStore.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Configuration/JsonDeviceRegistryStore.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Configuration;
+
+public sealed class JsonDeviceRegistryStore : IDeviceRegistryStore
+{
+    private readonly string _filePath;
+    private readonly JsonSerializerOptions _serializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters =
+        {
+            new JsonStringEnumConverter()
+        }
+    };
+
+    public JsonDeviceRegistryStore(string filePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        _filePath = filePath;
+    }
+
+    public async Task<DeviceRegistrySnapshot> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_filePath))
+        {
+            return new DeviceRegistrySnapshot();
+        }
+
+        await using var stream = File.OpenRead(_filePath);
+        var snapshot = await JsonSerializer
+            .DeserializeAsync<DeviceRegistrySnapshot>(stream, _serializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+
+        return snapshot ?? new DeviceRegistrySnapshot();
+    }
+
+    public async Task SaveAsync(DeviceRegistrySnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(_filePath);
+        await JsonSerializer
+            .SerializeAsync(stream, snapshot, _serializerOptions, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Infrastructure/InputAwareDisplaySwitcher.Infrastructure.csproj
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/InputAwareDisplaySwitcher.Infrastructure.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\InputAwareDisplaySwitcher.Core\InputAwareDisplaySwitcher.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/DisplayConfig/DisplayConfigInterop.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/DisplayConfig/DisplayConfigInterop.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.DisplayConfig;
+
+internal static class DisplayConfigInterop
+{
+    internal const int Success = 0;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern int SetDisplayConfig(
+        uint numPathArrayElements,
+        IntPtr pathArray,
+        uint numModeInfoArrayElements,
+        IntPtr modeInfoArray,
+        uint flags);
+}
+
+[Flags]
+internal enum SetDisplayConfigFlags : uint
+{
+    TopologyInternal = 0x00000001,
+    TopologyClone = 0x00000002,
+    TopologyExtend = 0x00000004,
+    TopologyExternal = 0x00000008,
+    Validate = 0x00000040,
+    Apply = 0x00000080,
+    SaveToDatabase = 0x00000200
+}

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/DisplayConfig/WindowsDisplaySwitcher.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/DisplayConfig/WindowsDisplaySwitcher.cs
@@ -1,0 +1,155 @@
+using System.ComponentModel;
+using InputAwareDisplaySwitcher.Core.Abstractions;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.DisplayConfig;
+
+public sealed class WindowsDisplaySwitcher : IDisplaySwitcher
+{
+    private const string HintKey = "windows.topology";
+
+    public Task<SwitchExecutionResult> ApplyAsync(DisplayProfile profile, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        if (!OperatingSystem.IsWindows())
+        {
+            return Task.FromResult(SwitchExecutionResult.Unsupported(
+                profile.DisplayProfileId,
+                "Windows display configuration API",
+                "The Windows display switcher can only run on Windows."));
+        }
+
+        if (!TryResolveTopology(profile, out var topologyFlag, out var topologyLabel, out var message))
+        {
+            return Task.FromResult(SwitchExecutionResult.Unsupported(
+                profile.DisplayProfileId,
+                "Windows display configuration API",
+                message));
+        }
+
+        var validationFlags = (uint)(SetDisplayConfigFlags.Validate | topologyFlag);
+        var applyFlags = (uint)(SetDisplayConfigFlags.Apply | SetDisplayConfigFlags.SaveToDatabase | topologyFlag);
+        var executionPath = $"SetDisplayConfig database topology ({topologyLabel})";
+
+        var validationStatus = DisplayConfigInterop.SetDisplayConfig(0, IntPtr.Zero, 0, IntPtr.Zero, validationFlags);
+        if (validationStatus != DisplayConfigInterop.Success)
+        {
+            return Task.FromResult(SwitchExecutionResult.Failure(
+                profile.DisplayProfileId,
+                executionPath,
+                $"Validation failed before apply. {FormatStatus(validationStatus)}",
+                validationStatus));
+        }
+
+        var applyStatus = DisplayConfigInterop.SetDisplayConfig(0, IntPtr.Zero, 0, IntPtr.Zero, applyFlags);
+        if (applyStatus != DisplayConfigInterop.Success)
+        {
+            return Task.FromResult(SwitchExecutionResult.Failure(
+                profile.DisplayProfileId,
+                executionPath,
+                $"Validation succeeded but apply failed. {FormatStatus(applyStatus)}",
+                applyStatus));
+        }
+
+        return Task.FromResult(SwitchExecutionResult.Succeeded(profile.DisplayProfileId, executionPath));
+    }
+
+    private static bool TryResolveTopology(
+        DisplayProfile profile,
+        out SetDisplayConfigFlags topologyFlag,
+        out string topologyLabel,
+        out string message)
+    {
+        if (profile.ImplementationHints.TryGetValue(HintKey, out var hintValue)
+            && TryParseTopologyHint(hintValue, out topologyFlag, out topologyLabel))
+        {
+            message = string.Empty;
+            return true;
+        }
+
+        switch (profile.IntentKind)
+        {
+            case DisplayProfileIntentKind.InternalOnly:
+                topologyFlag = SetDisplayConfigFlags.TopologyInternal;
+                topologyLabel = "Internal only";
+                message = string.Empty;
+                return true;
+            case DisplayProfileIntentKind.ExternalOnly:
+                topologyFlag = SetDisplayConfigFlags.TopologyExternal;
+                topologyLabel = "External only";
+                message = string.Empty;
+                return true;
+            case DisplayProfileIntentKind.Extend:
+                topologyFlag = SetDisplayConfigFlags.TopologyExtend;
+                topologyLabel = "Extend";
+                message = string.Empty;
+                return true;
+            case DisplayProfileIntentKind.Clone:
+                topologyFlag = SetDisplayConfigFlags.TopologyClone;
+                topologyLabel = "Clone";
+                message = string.Empty;
+                return true;
+            default:
+                topologyFlag = default;
+                topologyLabel = "Unsupported";
+                message = $"Profile '{profile.Name}' uses logical intent '{profile.IntentKind}' and needs a '{HintKey}' implementation hint before Windows can apply it.";
+                return false;
+        }
+    }
+
+    private static bool TryParseTopologyHint(
+        string? hintValue,
+        out SetDisplayConfigFlags topologyFlag,
+        out string topologyLabel)
+    {
+        switch (hintValue?.Trim().ToLowerInvariant())
+        {
+            case "internal":
+            case "internalonly":
+                topologyFlag = SetDisplayConfigFlags.TopologyInternal;
+                topologyLabel = "Internal only";
+                return true;
+            case "external":
+            case "externalonly":
+                topologyFlag = SetDisplayConfigFlags.TopologyExternal;
+                topologyLabel = "External only";
+                return true;
+            case "extend":
+                topologyFlag = SetDisplayConfigFlags.TopologyExtend;
+                topologyLabel = "Extend";
+                return true;
+            case "clone":
+            case "duplicate":
+                topologyFlag = SetDisplayConfigFlags.TopologyClone;
+                topologyLabel = "Clone";
+                return true;
+            default:
+                topologyFlag = default;
+                topologyLabel = "Unsupported";
+                return false;
+        }
+    }
+
+    private static string FormatStatus(int statusCode)
+    {
+        if (statusCode == DisplayConfigInterop.Success)
+        {
+            return "ERROR_SUCCESS (0): the Windows display configuration API reported success.";
+        }
+
+        var symbolicName = statusCode switch
+        {
+            5 => "ERROR_ACCESS_DENIED",
+            50 => "ERROR_NOT_SUPPORTED",
+            87 => "ERROR_INVALID_PARAMETER",
+            122 => "ERROR_INSUFFICIENT_BUFFER",
+            1168 => "ERROR_NOT_FOUND",
+            1610 => "ERROR_BAD_CONFIGURATION",
+            _ => "WIN32_ERROR"
+        };
+
+        return $"{symbolicName} ({statusCode}): {new Win32Exception(statusCode).Message}";
+    }
+}

--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,17 @@
 # Source Layout
 
-The `src/` directory is reserved for future production application code.
+The `src/` directory now contains the first production-ready MVP slice for the automatic switching pipeline.
 
-The likely long-term split is:
+Current projects:
 
-- `App` for the desktop application shell and UI integration
-- `Core` for domain logic such as zone mapping, state handling, and switching decisions
-- `Infrastructure` for Windows APIs, configuration storage, and logging
+- `InputAwareDisplaySwitcher.Core` for platform-neutral domain and application logic
+- `InputAwareDisplaySwitcher.Infrastructure` for JSON persistence and Windows display switching adapters
 
-The exact project structure should be decided after the feasibility prototypes confirm the technical approach.
+The current split follows the architecture docs directly:
+
+- `Core/Domain` models runtime device observations, persisted devices, zones, display profiles, policy, decisions, and execution outcomes
+- `Core/Application` contains the device registry service, decision engine v1, and orchestration path from observation to attempted switch
+- `Infrastructure/Configuration` contains JSON-backed registry persistence
+- `Infrastructure/Windows` contains the initial Windows display switcher implementation behind a core abstraction
+
+No WPF shell has been added yet. The current production code focuses on the reusable core + infrastructure boundaries needed for Issues #6, #7, and #8.

--- a/tests/InputAwareDisplaySwitcher.Tests/DecisionEngineV1Tests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/DecisionEngineV1Tests.cs
@@ -1,0 +1,177 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class DecisionEngineV1Tests
+{
+    private readonly DecisionEngineV1 _engine = new();
+
+    [Fact]
+    public void Evaluate_BlocksUnknownDevice()
+    {
+        var request = CreateRequest(new DeviceRegistryResolution
+        {
+            Status = DeviceRegistryResolutionStatus.UnknownDevice,
+            Observation = CreateObservation()
+        });
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.UnknownDevice, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_BlocksUnmappedDevice()
+    {
+        var request = CreateRequest(new DeviceRegistryResolution
+        {
+            Status = DeviceRegistryResolutionStatus.UnmappedZone,
+            Observation = CreateObservation(),
+            MatchedDevice = CreateDevice()
+        });
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.UnmappedDevice, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_BlocksWhenManualLockIsActive()
+    {
+        var request = CreateRequest(CreateResolvedResolution(), new ApplicationRuntimeState
+        {
+            IsManualSwitchingLocked = true
+        });
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.ManualLockActive, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_BlocksWhenCooldownIsActive()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var request = CreateRequest(
+            CreateResolvedResolution(),
+            new ApplicationRuntimeState
+            {
+                LastSwitchAtUtc = now.AddSeconds(-5)
+            },
+            new SwitchingPolicy
+            {
+                Cooldown = TimeSpan.FromSeconds(30)
+            },
+            now);
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.CooldownActive, decision.Reason);
+        Assert.NotNull(decision.CooldownEndsAtUtc);
+    }
+
+    [Fact]
+    public void Evaluate_ReturnsNoActionWhenZoneIsAlreadyActive()
+    {
+        var request = CreateRequest(
+            CreateResolvedResolution(),
+            new ApplicationRuntimeState
+            {
+                CurrentZoneId = "desk",
+                CurrentDisplayProfileId = "desk-profile"
+            });
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.NoAction, decision.Status);
+        Assert.Equal(SwitchDecisionReason.AlreadyActive, decision.Reason);
+    }
+
+    [Fact]
+    public void Evaluate_AllowsSwitchForValidMappedDevice()
+    {
+        var request = CreateRequest(CreateResolvedResolution());
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Allowed, decision.Status);
+        Assert.Equal(SwitchDecisionReason.Allowed, decision.Reason);
+        Assert.True(decision.ShouldSwitch);
+        Assert.Equal("desk", decision.TargetZoneId);
+        Assert.Equal("desk-profile", decision.TargetDisplayProfileId);
+    }
+
+    private static DecisionRequest CreateRequest(
+        DeviceRegistryResolution resolution,
+        ApplicationRuntimeState? runtimeState = null,
+        SwitchingPolicy? policy = null,
+        DateTimeOffset? evaluatedAtUtc = null)
+    {
+        return new DecisionRequest
+        {
+            Observation = resolution.Observation,
+            Resolution = resolution,
+            RuntimeState = runtimeState ?? new ApplicationRuntimeState(),
+            Policy = policy ?? new SwitchingPolicy(),
+            EvaluatedAtUtc = evaluatedAtUtc ?? DateTimeOffset.UtcNow
+        };
+    }
+
+    private static DeviceRegistryResolution CreateResolvedResolution()
+    {
+        var device = CreateDevice();
+        var zone = new ZoneDefinition
+        {
+            ZoneId = "desk",
+            Name = "Desk",
+            PreferredDisplayProfileId = "desk-profile"
+        };
+        var profile = new DisplayProfile
+        {
+            DisplayProfileId = "desk-profile",
+            Name = "Desk Only",
+            IntentKind = DisplayProfileIntentKind.ExternalOnly
+        };
+
+        return new DeviceRegistryResolution
+        {
+            Status = DeviceRegistryResolutionStatus.Resolved,
+            Observation = CreateObservation(),
+            MatchedDevice = device,
+            Zone = zone,
+            TargetProfile = profile
+        };
+    }
+
+    private static PersistedDeviceIdentity CreateDevice()
+    {
+        return new PersistedDeviceIdentity
+        {
+            DeviceId = "keyboard-1",
+            FriendlyName = "Desk Keyboard",
+            DeviceKind = DeviceKind.Keyboard,
+            PreferredPersistenceKey = "instance:desk-keyboard",
+            AssignedZoneId = "desk"
+        };
+    }
+
+    private static RuntimeDeviceObservation CreateObservation()
+    {
+        return new RuntimeDeviceObservation
+        {
+            SessionDeviceId = "session-1",
+            DeviceKind = DeviceKind.Keyboard,
+            InstanceId = "desk-keyboard",
+            FriendlyName = "Desk Keyboard",
+            ObservedAtUtc = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/DeviceRegistryServiceTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/DeviceRegistryServiceTests.cs
@@ -1,0 +1,89 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class DeviceRegistryServiceTests
+{
+    [Fact]
+    public void Resolve_ReturnsZoneForMultipleDevicesMappedToSameZone()
+    {
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard",
+                    AssignedZoneId = "desk"
+                },
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "mouse-1",
+                    FriendlyName = "Desk Mouse",
+                    DeviceKind = DeviceKind.Mouse,
+                    PreferredPersistenceKey = "instance:desk-mouse",
+                    AssignedZoneId = "desk"
+                }
+            ],
+            Zones =
+            [
+                new ZoneDefinition
+                {
+                    ZoneId = "desk",
+                    Name = "Desk",
+                    PreferredDisplayProfileId = "desk-profile"
+                }
+            ],
+            DisplayProfiles =
+            [
+                new DisplayProfile
+                {
+                    DisplayProfileId = "desk-profile",
+                    Name = "Desk Only",
+                    IntentKind = DisplayProfileIntentKind.ExternalOnly
+                }
+            ]
+        };
+
+        var service = new DeviceRegistryService(new InMemoryDeviceRegistryStore(snapshot));
+        var resolution = service.Resolve(new RuntimeDeviceObservation
+        {
+            SessionDeviceId = "mouse-session",
+            DeviceKind = DeviceKind.Mouse,
+            InstanceId = "desk-mouse",
+            FriendlyName = "Desk Mouse",
+            ObservedAtUtc = DateTimeOffset.UtcNow
+        }, snapshot);
+
+        Assert.Equal(DeviceRegistryResolutionStatus.Resolved, resolution.Status);
+        Assert.Equal("mouse-1", resolution.MatchedDevice?.DeviceId);
+        Assert.Equal("desk", resolution.Zone?.ZoneId);
+        Assert.Equal("desk-profile", resolution.TargetProfile?.DisplayProfileId);
+    }
+
+    [Fact]
+    public void Resolve_HandlesUnknownDeviceGracefully()
+    {
+        var snapshot = new DeviceRegistrySnapshot();
+        var service = new DeviceRegistryService(new InMemoryDeviceRegistryStore(snapshot));
+
+        var resolution = service.Resolve(new RuntimeDeviceObservation
+        {
+            SessionDeviceId = "unknown-session",
+            DeviceKind = DeviceKind.Keyboard,
+            InstanceId = "unknown-device",
+            FriendlyName = "Unknown Keyboard",
+            ObservedAtUtc = DateTimeOffset.UtcNow
+        }, snapshot);
+
+        Assert.Equal(DeviceRegistryResolutionStatus.UnknownDevice, resolution.Status);
+        Assert.Null(resolution.MatchedDevice);
+        Assert.Contains("No persisted device mapping matched", resolution.Message);
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/GlobalUsings.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/InputAwareDisplaySwitcher.Tests/InputAwareDisplaySwitcher.Tests.csproj
+++ b/tests/InputAwareDisplaySwitcher.Tests/InputAwareDisplaySwitcher.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\InputAwareDisplaySwitcher.Core\InputAwareDisplaySwitcher.Core.csproj" />
+    <ProjectReference Include="..\..\src\InputAwareDisplaySwitcher.Infrastructure\InputAwareDisplaySwitcher.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/InputAwareDisplaySwitcher.Tests/JsonDeviceRegistryStoreTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/JsonDeviceRegistryStoreTests.cs
@@ -1,0 +1,72 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+using InputAwareDisplaySwitcher.Infrastructure.Configuration;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class JsonDeviceRegistryStoreTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"iads-tests-{Guid.NewGuid():N}");
+
+    [Fact]
+    public async Task SaveAndLoadAsync_RoundTripsRegistryData()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var filePath = Path.Combine(_tempDirectory, "registry.json");
+        var store = new JsonDeviceRegistryStore(filePath);
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard",
+                    AssignedZoneId = "desk"
+                }
+            ],
+            Zones =
+            [
+                new ZoneDefinition
+                {
+                    ZoneId = "desk",
+                    Name = "Desk",
+                    PreferredDisplayProfileId = "desk-profile"
+                }
+            ],
+            DisplayProfiles =
+            [
+                new DisplayProfile
+                {
+                    DisplayProfileId = "desk-profile",
+                    Name = "Desk Only",
+                    IntentKind = DisplayProfileIntentKind.ExternalOnly,
+                    ImplementationHints = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["windows.topology"] = "external"
+                    }
+                }
+            ]
+        };
+
+        await store.SaveAsync(snapshot);
+        var loaded = await store.LoadAsync();
+
+        Assert.Single(loaded.Devices);
+        Assert.Single(loaded.Zones);
+        Assert.Single(loaded.DisplayProfiles);
+        Assert.Equal("desk", loaded.Devices[0].AssignedZoneId);
+        Assert.Equal("external", loaded.DisplayProfiles[0].ImplementationHints["windows.topology"]);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/SwitchingOrchestratorTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/SwitchingOrchestratorTests.cs
@@ -1,0 +1,99 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class SwitchingOrchestratorTests
+{
+    [Fact]
+    public async Task ProcessAsync_DoesNotCallDisplaySwitcherForBlockedDecision()
+    {
+        var snapshot = new DeviceRegistrySnapshot();
+        var switcher = new RecordingDisplaySwitcher();
+        var orchestrator = new SwitchingOrchestrator(
+            new DeviceRegistryService(new InMemoryDeviceRegistryStore(snapshot)),
+            new DecisionEngineV1(),
+            switcher);
+
+        var outcome = await orchestrator.ProcessAsync(
+            new RuntimeDeviceObservation
+            {
+                SessionDeviceId = "unknown-session",
+                DeviceKind = DeviceKind.Keyboard,
+                InstanceId = "unknown",
+                ObservedAtUtc = DateTimeOffset.UtcNow
+            },
+            new ApplicationRuntimeState(),
+            new SwitchingPolicy());
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, outcome.Decision.Status);
+        Assert.Equal(0, switcher.CallCount);
+        Assert.Equal(SwitchExecutionStatus.NotAttempted, outcome.ExecutionResult.Status);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_CallsDisplaySwitcherWhenDecisionIsAllowed()
+    {
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard",
+                    AssignedZoneId = "desk"
+                }
+            ],
+            Zones =
+            [
+                new ZoneDefinition
+                {
+                    ZoneId = "desk",
+                    Name = "Desk",
+                    PreferredDisplayProfileId = "desk-profile"
+                }
+            ],
+            DisplayProfiles =
+            [
+                new DisplayProfile
+                {
+                    DisplayProfileId = "desk-profile",
+                    Name = "Desk Only",
+                    IntentKind = DisplayProfileIntentKind.ExternalOnly
+                }
+            ]
+        };
+
+        var switcher = new RecordingDisplaySwitcher();
+        var orchestrator = new SwitchingOrchestrator(
+            new DeviceRegistryService(new InMemoryDeviceRegistryStore(snapshot)),
+            new DecisionEngineV1(),
+            switcher);
+
+        var outcome = await orchestrator.ProcessAsync(
+            new RuntimeDeviceObservation
+            {
+                SessionDeviceId = "desk-session",
+                DeviceKind = DeviceKind.Keyboard,
+                InstanceId = "desk-keyboard",
+                FriendlyName = "Desk Keyboard",
+                ObservedAtUtc = DateTimeOffset.UtcNow
+            },
+            new ApplicationRuntimeState(),
+            new SwitchingPolicy
+            {
+                Cooldown = TimeSpan.Zero
+            });
+
+        Assert.Equal(SwitchDecisionStatus.Allowed, outcome.Decision.Status);
+        Assert.Equal(1, switcher.CallCount);
+        Assert.Equal("desk-profile", switcher.LastProfile?.DisplayProfileId);
+        Assert.Equal(SwitchExecutionStatus.Succeeded, outcome.ExecutionResult.Status);
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/TestDoubles.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/TestDoubles.cs
@@ -1,0 +1,45 @@
+using InputAwareDisplaySwitcher.Core.Abstractions;
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+internal sealed class InMemoryDeviceRegistryStore : IDeviceRegistryStore
+{
+    private DeviceRegistrySnapshot _snapshot;
+
+    public InMemoryDeviceRegistryStore(DeviceRegistrySnapshot? snapshot = null)
+    {
+        _snapshot = snapshot ?? new DeviceRegistrySnapshot();
+    }
+
+    public Task<DeviceRegistrySnapshot> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_snapshot);
+    }
+
+    public Task SaveAsync(DeviceRegistrySnapshot snapshot, CancellationToken cancellationToken = default)
+    {
+        _snapshot = snapshot;
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class RecordingDisplaySwitcher : IDisplaySwitcher
+{
+    public int CallCount { get; private set; }
+
+    public DisplayProfile? LastProfile { get; private set; }
+
+    public Task<SwitchExecutionResult> ApplyAsync(DisplayProfile profile, CancellationToken cancellationToken = default)
+    {
+        CallCount++;
+        LastProfile = profile;
+
+        return Task.FromResult(SwitchExecutionResult.Succeeded(
+            profile.DisplayProfileId,
+            "Fake display switcher"));
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,17 @@
 # Testing Strategy
 
-The `tests/` directory is reserved for future automated tests and supporting test assets.
+The `tests/` directory contains automated coverage for the new MVP switching slice.
 
-Planned testing approach:
+Current focus:
 
-- unit tests for mapping, policy, and decision logic
-- integration-style tests where practical for persistence and orchestration boundaries
-- manual validation for Windows-specific hardware behaviour that cannot be reliably automated in early stages
+- unit tests for device registry resolution and zone mapping
+- unit tests for decision engine v1 rule outcomes
+- orchestration-boundary tests to prove blocked decisions do not execute and allowed decisions do
+- JSON persistence round-trip testing for the registry store
 
-Hardware-dependent behaviour should also be documented alongside prototype findings in `docs/research/feasibility-notes.md`.
+Still intentionally out of scope for automation:
+
+- end-to-end Raw Input hardware attribution
+- real Windows display switching success across monitor/TV hardware combinations
+
+Those behaviours remain prototype/manual-validation concerns and should continue to be recorded in `docs/research/feasibility-notes.md`.


### PR DESCRIPTION
## Summary

Implements the first production MVP slice for automatic display switching by adding a persisted device registry with zone/profile mapping, a rule-based decision engine, and a Windows display switcher abstraction. The main outcome is a clean end-to-end path from runtime device observation to an explainable switching decision and, when allowed, an attempted Windows display switch.

## Related Issue

Closes #6  
Closes #7  
Closes #8

## Scope of Changes

- Added new production `Core` and `Infrastructure` projects plus a test project, and updated the solution to include them
- Implemented persisted device identity, zone mapping, JSON-backed registry storage, and resolution logic for known vs unknown/unmapped devices
- Implemented decision engine v1, switching orchestration, Windows display switcher abstraction, and automated tests covering registry, decision, orchestration, and persistence behaviour

## Validation

Built the full solution and ran the automated test suite locally on Windows.

Commands used:

```powershell
dotnet build .\input-aware-display-switcher.sln
dotnet test .\tests\InputAwareDisplaySwitcher.Tests\InputAwareDisplaySwitcher.Tests.csproj
dotnet test .\input-aware-display-switcher.sln
```

Result:
- Solution build succeeded
- 11 automated tests passed
- Existing Windows feasibility prototypes still build successfully as part of the solution

## Documentation Impact

- [ ] No documentation changes required
- [x] Documentation updated in this PR

## Checklist

- [x] The change is focused and within issue scope
- [x] Relevant docs were updated where needed
- [x] Validation appropriate to the change was completed
- [x] No unrelated implementation or cleanup was bundled into this PR