### PR TITLE
[#9] - build mvp end to end automatic switching flow

### DIFF
--- a/src/InputAwareDisplaySwitcher.Core/Application/AutomaticSwitchingController.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/AutomaticSwitchingController.cs
@@ -1,0 +1,100 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class AutomaticSwitchingController
+{
+    private readonly IInputActivitySource _inputActivitySource;
+    private readonly SwitchingOrchestrator _orchestrator;
+    private readonly IRuntimeStateStore _runtimeStateStore;
+    private readonly ISwitchingOutcomeRecorder _outcomeRecorder;
+    private readonly SwitchingPolicy _policy;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _isStarted;
+
+    public AutomaticSwitchingController(
+        IInputActivitySource inputActivitySource,
+        SwitchingOrchestrator orchestrator,
+        IRuntimeStateStore runtimeStateStore,
+        ISwitchingOutcomeRecorder outcomeRecorder,
+        SwitchingPolicy policy)
+    {
+        _inputActivitySource = inputActivitySource;
+        _orchestrator = orchestrator;
+        _runtimeStateStore = runtimeStateStore;
+        _outcomeRecorder = outcomeRecorder;
+        _policy = policy;
+    }
+
+    public void Start()
+    {
+        if (_isStarted)
+        {
+            return;
+        }
+
+        _inputActivitySource.ActivityObserved += OnActivityObservedAsync;
+        _isStarted = true;
+    }
+
+    public void Stop()
+    {
+        if (!_isStarted)
+        {
+            return;
+        }
+
+        _inputActivitySource.ActivityObserved -= OnActivityObservedAsync;
+        _isStarted = false;
+    }
+
+    public async Task<SwitchingOutcome> HandleObservationAsync(
+        Core.Domain.Devices.RuntimeDeviceObservation observation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(observation);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var runtimeState = await _runtimeStateStore.LoadAsync(cancellationToken).ConfigureAwait(false);
+
+            var outcome = await _orchestrator
+                .ProcessAsync(observation, runtimeState, _policy, cancellationToken)
+                .ConfigureAwait(false);
+
+            var updatedState = BuildUpdatedState(runtimeState, outcome);
+
+            await _runtimeStateStore.SaveAsync(updatedState, cancellationToken).ConfigureAwait(false);
+            await _outcomeRecorder.RecordAsync(outcome, cancellationToken).ConfigureAwait(false);
+
+            return outcome;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private Task OnActivityObservedAsync(Core.Domain.Devices.RuntimeDeviceObservation observation, CancellationToken cancellationToken)
+    {
+        return HandleObservationAsync(observation, cancellationToken);
+    }
+
+    private static ApplicationRuntimeState BuildUpdatedState(ApplicationRuntimeState currentState, SwitchingOutcome outcome)
+    {
+        return currentState with
+        {
+            CurrentZoneId = outcome.ExecutionResult.Success
+                ? outcome.Decision.TargetZoneId
+                : currentState.CurrentZoneId,
+            CurrentDisplayProfileId = outcome.ExecutionResult.Success
+                ? outcome.Decision.TargetDisplayProfileId
+                : currentState.CurrentDisplayProfileId,
+            LastSwitchAtUtc = outcome.ExecutionResult.Success
+                ? outcome.ExecutionResult.RecordedAtUtc
+                : currentState.LastSwitchAtUtc,
+            LastMatchedDeviceId = outcome.Decision.MatchedDeviceId ?? currentState.LastMatchedDeviceId
+        };
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/IInputActivitySource.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/IInputActivitySource.cs
@@ -1,0 +1,10 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public delegate Task InputActivityObservedHandler(RuntimeDeviceObservation observation, CancellationToken cancellationToken);
+
+public interface IInputActivitySource
+{
+    event InputActivityObservedHandler? ActivityObserved;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/IRuntimeStateStore.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/IRuntimeStateStore.cs
@@ -1,0 +1,10 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public interface IRuntimeStateStore
+{
+    Task<ApplicationRuntimeState> LoadAsync(CancellationToken cancellationToken = default);
+
+    Task SaveAsync(ApplicationRuntimeState state, CancellationToken cancellationToken = default);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/ISwitchingOutcomeRecorder.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/ISwitchingOutcomeRecorder.cs
@@ -1,0 +1,6 @@
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public interface ISwitchingOutcomeRecorder
+{
+    Task RecordAsync(SwitchingOutcome outcome, CancellationToken cancellationToken = default);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/InMemoryRuntimeStateStore.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/InMemoryRuntimeStateStore.cs
@@ -1,0 +1,25 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class InMemoryRuntimeStateStore : IRuntimeStateStore
+{
+    private ApplicationRuntimeState _state;
+
+    public InMemoryRuntimeStateStore(ApplicationRuntimeState? initialState = null)
+    {
+        _state = initialState ?? new ApplicationRuntimeState();
+    }
+
+    public Task<ApplicationRuntimeState> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_state);
+    }
+
+    public Task SaveAsync(ApplicationRuntimeState state, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        _state = state;
+        return Task.CompletedTask;
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/InMemorySwitchingOutcomeRecorder.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/InMemorySwitchingOutcomeRecorder.cs
@@ -1,0 +1,15 @@
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class InMemorySwitchingOutcomeRecorder : ISwitchingOutcomeRecorder
+{
+    private readonly List<SwitchingOutcome> _outcomes = [];
+
+    public IReadOnlyList<SwitchingOutcome> Outcomes => _outcomes;
+
+    public Task RecordAsync(SwitchingOutcome outcome, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(outcome);
+        _outcomes.Add(outcome);
+        return Task.CompletedTask;
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/AutomaticSwitchingControllerTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/AutomaticSwitchingControllerTests.cs
@@ -1,0 +1,195 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class AutomaticSwitchingControllerTests
+{
+    [Fact]
+    public async Task Start_WhenMappedDeviceInputArrives_InvokesSwitcherWithResolvedProfile()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new RecordingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var controller = CreateController(input, switcher, recorder, new ApplicationRuntimeState(), new SwitchingPolicy { Cooldown = TimeSpan.Zero });
+
+        controller.Start();
+        await input.PublishAsync(CreateMappedObservation());
+
+        Assert.Equal(1, switcher.CallCount);
+        Assert.Equal("desk-profile", switcher.LastProfile?.DisplayProfileId);
+        Assert.Single(recorder.Outcomes);
+        Assert.Equal(SwitchDecisionStatus.Allowed, recorder.Outcomes[0].Decision.Status);
+    }
+
+    [Fact]
+    public async Task HandleObservationAsync_ForUnknownDevice_BlocksAndRecordsReason()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new RecordingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var controller = CreateController(input, switcher, recorder);
+
+        var outcome = await controller.HandleObservationAsync(new RuntimeDeviceObservation
+        {
+            SessionDeviceId = "unknown-session",
+            DeviceKind = DeviceKind.Keyboard,
+            InstanceId = "unknown-instance",
+            ObservedAtUtc = DateTimeOffset.UtcNow
+        });
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, outcome.Decision.Status);
+        Assert.Equal(SwitchDecisionReason.UnknownDevice, outcome.Decision.Reason);
+        Assert.Equal(0, switcher.CallCount);
+        Assert.Equal(outcome, recorder.Outcomes.Single());
+    }
+
+    [Fact]
+    public async Task HandleObservationAsync_WhenCooldownActive_BlocksAndDoesNotSwitch()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new RecordingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var runtimeState = new ApplicationRuntimeState
+        {
+            LastSwitchAtUtc = DateTimeOffset.UtcNow.AddSeconds(-5)
+        };
+
+        var controller = CreateController(
+            input,
+            switcher,
+            recorder,
+            runtimeState,
+            new SwitchingPolicy { Cooldown = TimeSpan.FromSeconds(30) });
+
+        var outcome = await controller.HandleObservationAsync(CreateMappedObservation());
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, outcome.Decision.Status);
+        Assert.Equal(SwitchDecisionReason.CooldownActive, outcome.Decision.Reason);
+        Assert.Equal(0, switcher.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleObservationAsync_WhenManualLockActive_BlocksAndDoesNotSwitch()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new RecordingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var runtimeState = new ApplicationRuntimeState
+        {
+            IsManualSwitchingLocked = true
+        };
+
+        var controller = CreateController(input, switcher, recorder, runtimeState);
+
+        var outcome = await controller.HandleObservationAsync(CreateMappedObservation());
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, outcome.Decision.Status);
+        Assert.Equal(SwitchDecisionReason.ManualLockActive, outcome.Decision.Reason);
+        Assert.Equal(0, switcher.CallCount);
+    }
+
+    [Fact]
+    public async Task HandleObservationAsync_WhenSwitchSucceeds_RecordsSuccessfulExecution()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new RecordingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var controller = CreateController(input, switcher, recorder, new ApplicationRuntimeState(), new SwitchingPolicy { Cooldown = TimeSpan.Zero });
+
+        var outcome = await controller.HandleObservationAsync(CreateMappedObservation());
+
+        Assert.Equal(SwitchDecisionStatus.Allowed, outcome.Decision.Status);
+        Assert.Equal(SwitchExecutionStatus.Succeeded, outcome.ExecutionResult.Status);
+        Assert.Equal("desk-profile", outcome.ExecutionResult.DisplayProfileId);
+        Assert.Equal(outcome, recorder.Outcomes.Single());
+    }
+
+    [Fact]
+    public async Task HandleObservationAsync_WhenSwitcherFails_RecordsFailure()
+    {
+        var input = new TestInputActivitySource();
+        var switcher = new FailingDisplaySwitcher();
+        var recorder = new RecordingOutcomeRecorder();
+        var controller = CreateController(input, switcher, recorder, new ApplicationRuntimeState(), new SwitchingPolicy { Cooldown = TimeSpan.Zero });
+
+        var outcome = await controller.HandleObservationAsync(CreateMappedObservation());
+
+        Assert.Equal(SwitchDecisionStatus.Allowed, outcome.Decision.Status);
+        Assert.Equal(SwitchExecutionStatus.Failed, outcome.ExecutionResult.Status);
+        Assert.Equal("Injected switch failure.", outcome.ExecutionResult.ErrorMessage);
+        Assert.Equal(1, switcher.CallCount);
+        Assert.Equal(outcome, recorder.Outcomes.Single());
+    }
+
+    private static AutomaticSwitchingController CreateController(
+        TestInputActivitySource input,
+        InputAwareDisplaySwitcher.Core.Abstractions.IDisplaySwitcher switcher,
+        RecordingOutcomeRecorder recorder,
+        ApplicationRuntimeState? runtimeState = null,
+        SwitchingPolicy? policy = null)
+    {
+        var orchestrator = new SwitchingOrchestrator(
+            new DeviceRegistryService(new InMemoryDeviceRegistryStore(CreateMappedSnapshot())),
+            new DecisionEngineV1(),
+            switcher);
+
+        return new AutomaticSwitchingController(
+            input,
+            orchestrator,
+            new InMemoryRuntimeStateStore(runtimeState),
+            recorder,
+            policy ?? new SwitchingPolicy());
+    }
+
+    private static DeviceRegistrySnapshot CreateMappedSnapshot()
+    {
+        return new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard",
+                    AssignedZoneId = "desk"
+                }
+            ],
+            Zones =
+            [
+                new ZoneDefinition
+                {
+                    ZoneId = "desk",
+                    Name = "Desk",
+                    PreferredDisplayProfileId = "desk-profile"
+                }
+            ],
+            DisplayProfiles =
+            [
+                new DisplayProfile
+                {
+                    DisplayProfileId = "desk-profile",
+                    Name = "Desk Only",
+                    IntentKind = DisplayProfileIntentKind.ExternalOnly
+                }
+            ]
+        };
+    }
+
+    private static RuntimeDeviceObservation CreateMappedObservation()
+    {
+        return new RuntimeDeviceObservation
+        {
+            SessionDeviceId = "desk-session",
+            DeviceKind = DeviceKind.Keyboard,
+            InstanceId = "desk-keyboard",
+            FriendlyName = "Desk Keyboard",
+            ObservedAtUtc = DateTimeOffset.UtcNow
+        };
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/TestDoubles.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/TestDoubles.cs
@@ -43,3 +43,41 @@ internal sealed class RecordingDisplaySwitcher : IDisplaySwitcher
             "Fake display switcher"));
     }
 }
+
+internal sealed class FailingDisplaySwitcher : IDisplaySwitcher
+{
+    public int CallCount { get; private set; }
+
+    public Task<SwitchExecutionResult> ApplyAsync(DisplayProfile profile, CancellationToken cancellationToken = default)
+    {
+        CallCount++;
+
+        return Task.FromResult(SwitchExecutionResult.Failure(
+            profile.DisplayProfileId,
+            "Fake display switcher",
+            "Injected switch failure."));
+    }
+}
+
+internal sealed class TestInputActivitySource : IInputActivitySource
+{
+    public event InputActivityObservedHandler? ActivityObserved;
+
+    public Task PublishAsync(RuntimeDeviceObservation observation, CancellationToken cancellationToken = default)
+    {
+        return ActivityObserved?.Invoke(observation, cancellationToken) ?? Task.CompletedTask;
+    }
+}
+
+internal sealed class RecordingOutcomeRecorder : ISwitchingOutcomeRecorder
+{
+    private readonly List<SwitchingOutcome> _outcomes = [];
+
+    public IReadOnlyList<SwitchingOutcome> Outcomes => _outcomes;
+
+    public Task RecordAsync(SwitchingOutcome outcome, CancellationToken cancellationToken = default)
+    {
+        _outcomes.Add(outcome);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Implement the MVP automatic switching controller flow that connects input activity events to the existing switching orchestration pipeline. This adds a controller responsible for subscribing to runtime observations, processing switching decisions, persisting runtime state updates, and recording switching outcomes.

## Related Issue

Closes #9

## Scope of Changes

- Add `AutomaticSwitchingController` to coordinate input activity, orchestration, runtime state persistence, and outcome recording
- Introduce supporting abstractions and in-memory implementations for input activity, runtime state storage, and outcome recording
- Add unit tests covering mapped-device switching, unknown-device blocking, cooldown/manual-lock blocking, and success/failure outcome recording

## Validation

Ran targeted automated tests locally:

```powershell
dotnet test .\tests\InputAwareDisplaySwitcher.Tests\InputAwareDisplaySwitcher.Tests.csproj --filter AutomaticSwitchingControllerTests
```

Result:
- 6 tests run
- 0 failed
- 6 passed

## Documentation Impact

- [x] No documentation changes required
- [ ] Documentation updated in this PR

## Checklist

- [x] The change is focused and within issue scope
- [x] Relevant docs were updated where needed
- [x] Validation appropriate to the change was completed
- [x] No unrelated implementation or cleanup was bundled into this PR
