### PR TITLE
[#13, #14] - implement device management and rules settings screens

### DIFF
--- a/src/InputAwareDisplaySwitcher.App/App.xaml.cs
+++ b/src/InputAwareDisplaySwitcher.App/App.xaml.cs
@@ -4,6 +4,7 @@ using InputAwareDisplaySwitcher.Core.Application;
 using InputAwareDisplaySwitcher.Core.Domain.Diagnostics;
 using InputAwareDisplaySwitcher.Infrastructure.Configuration;
 using InputAwareDisplaySwitcher.Infrastructure.Diagnostics;
+using InputAwareDisplaySwitcher.Infrastructure.Windows.Input;
 using InputAwareDisplaySwitcher.App.ViewModels;
 
 namespace InputAwareDisplaySwitcher.App;
@@ -35,10 +36,18 @@ public partial class App : Application
             var configurationStore = new JsonAppConfigurationStore(configurationPath, diagnostics);
             var configurationService = new ApplicationConfigurationService(configurationStore);
             var configuration = await configurationService.LoadAsync();
+            var configurationSession = new AppConfigurationSession(configurationService, configuration);
+            var deviceManagementService = new DeviceManagementService();
+            var deviceSnapshotProvider = new WindowsInputDeviceSnapshotProvider(diagnostics);
 
             var mainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(configuration, diagnostics, configurationPath)
+                DataContext = new MainWindowViewModel(
+                    configurationSession,
+                    deviceSnapshotProvider,
+                    deviceManagementService,
+                    diagnostics,
+                    configurationPath)
             };
 
             diagnostics.Record(

--- a/src/InputAwareDisplaySwitcher.App/MainWindow.xaml.cs
+++ b/src/InputAwareDisplaySwitcher.App/MainWindow.xaml.cs
@@ -8,4 +8,14 @@ public partial class MainWindow : Window
     {
         InitializeComponent();
     }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        base.OnClosed(e);
+    }
 }

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/DeviceEditRequest.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/DeviceEditRequest.cs
@@ -1,0 +1,12 @@
+using InputAwareDisplaySwitcher.Core.Application;
+
+namespace InputAwareDisplaySwitcher.App.ViewModels;
+
+public sealed record DeviceEditRequest
+{
+    public required DeviceManagementEntry Entry { get; init; }
+
+    public required string FriendlyName { get; init; }
+
+    public string? AssignedZoneId { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/DeviceRowViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/DeviceRowViewModel.cs
@@ -1,0 +1,127 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.App.ViewModels;
+
+public sealed class DeviceRowViewModel : ObservableObject
+{
+    private readonly Action<DeviceEditRequest>? _onDeviceEdited;
+    private readonly DeviceManagementEntry _entry;
+    private string _friendlyName;
+    private string? _assignedZoneId;
+
+    public DeviceRowViewModel(DeviceManagementEntry entry, Action<DeviceEditRequest>? onDeviceEdited = null)
+    {
+        _entry = entry ?? throw new ArgumentNullException(nameof(entry));
+        _friendlyName = entry.DisplayName;
+        _assignedZoneId = entry.AssignedZoneId;
+        _onDeviceEdited = onDeviceEdited;
+    }
+
+    public string EntryId => _entry.EntryId;
+
+    public string FriendlyName
+    {
+        get => _friendlyName;
+        set
+        {
+            var normalized = NormalizeFriendlyName(value);
+            if (!SetProperty(ref _friendlyName, normalized))
+            {
+                return;
+            }
+
+            PublishEdit();
+        }
+    }
+
+    public string DeviceKindDisplay => _entry.DeviceKind switch
+    {
+        DeviceKind.Keyboard => "Keyboard",
+        DeviceKind.Mouse => "Mouse",
+        DeviceKind.PointingDevice => "Pointing device",
+        _ => "Unknown"
+    };
+
+    public bool IsAssigned => _assignedZoneId is not null && _entry.AssignmentState == DeviceAssignmentState.Assigned;
+
+    public string AssignmentStatus
+    {
+        get
+        {
+            if (_assignedZoneId is null)
+            {
+                return "Unassigned";
+            }
+
+            return _entry.AssignmentState == DeviceAssignmentState.UnknownZone
+                && string.Equals(_assignedZoneId, _entry.AssignedZoneId, StringComparison.OrdinalIgnoreCase)
+                ? "Zone missing"
+                : "Assigned";
+        }
+    }
+
+    public string? AssignedZoneId
+    {
+        get => _assignedZoneId;
+        set
+        {
+            var normalized = string.IsNullOrWhiteSpace(value) ? null : value;
+            if (!SetProperty(ref _assignedZoneId, normalized))
+            {
+                return;
+            }
+
+            OnPropertyChanged(nameof(IsAssigned));
+            OnPropertyChanged(nameof(AssignmentStatus));
+            OnPropertyChanged(nameof(AssignedZoneDisplayName));
+            PublishEdit();
+        }
+    }
+
+    public string AssignedZoneDisplayName => _assignedZoneId is null
+        ? "No zone assigned"
+        : _entry.AssignedZoneName ?? _assignedZoneId;
+
+    public string AvailabilityStatus => _entry.IsDetectedThisSession
+        ? "Detected now"
+        : "Remembered only";
+
+    public bool IsDetectedThisSession => _entry.IsDetectedThisSession;
+
+    public bool CanEdit => _entry.CanPersistEdits;
+
+    public string StableIdentitySummary => _entry.StableIdentitySummary;
+
+    public string IdentitySummary => StableIdentitySummary;
+
+    public string MetadataSummary => _entry.MetadataSummary;
+
+    public string EnabledState => _entry.IsEnabled ? "Enabled" : "Disabled";
+
+    public string? PersistenceWarning => _entry.PersistenceWarning;
+
+    public string LastSeenDisplay => _entry.LastSeenAtUtc.HasValue
+        ? _entry.LastSeenAtUtc.Value.LocalDateTime.ToString("g")
+        : "Not seen yet";
+
+    private void PublishEdit()
+    {
+        if (!CanEdit)
+        {
+            return;
+        }
+
+        _onDeviceEdited?.Invoke(new DeviceEditRequest
+        {
+            Entry = _entry,
+            FriendlyName = _friendlyName,
+            AssignedZoneId = _assignedZoneId
+        });
+    }
+
+    private string NormalizeFriendlyName(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? _entry.DisplayName : value.Trim();
+    }
+}

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/DevicesViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/DevicesViewModel.cs
@@ -1,14 +1,210 @@
+using System.Collections.ObjectModel;
+using System.Windows;
+using System.Windows.Threading;
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Configuration;
 using InputAwareDisplaySwitcher.Core.Domain.Devices;
 
 namespace InputAwareDisplaySwitcher.App.ViewModels;
 
 public sealed class DevicesViewModel : SectionViewModelBase
 {
-    public DevicesViewModel(IReadOnlyList<PersistedDeviceIdentity> devices)
-        : base("Devices", "Saved physical device identities and their zone assignments.")
+    private readonly AppConfigurationSession _configurationSession;
+    private readonly IInputDeviceSnapshotProvider _snapshotProvider;
+    private readonly DeviceManagementService _deviceManagementService;
+    private readonly Action? _openZonesProfiles;
+    private readonly RelayCommand _refreshCommand;
+    private readonly RelayCommand _openZonesProfilesCommand;
+    private readonly DispatcherTimer _refreshTimer;
+    private IReadOnlyList<RuntimeDeviceObservation> _runtimeDevices = [];
+    private bool _isRefreshing;
+    private string? _refreshStatusMessage;
+    private bool _refreshStatusIsError;
+    private DateTimeOffset? _lastRefreshedAtUtc;
+
+    public DevicesViewModel(
+        AppConfigurationSession configurationSession,
+        IInputDeviceSnapshotProvider snapshotProvider,
+        DeviceManagementService deviceManagementService,
+        Action? openZonesProfiles = null)
+        : base("Devices", "Detected input devices, app-local aliases, and zone assignments.")
     {
-        Devices = devices;
+        _configurationSession = configurationSession ?? throw new ArgumentNullException(nameof(configurationSession));
+        _snapshotProvider = snapshotProvider ?? throw new ArgumentNullException(nameof(snapshotProvider));
+        _deviceManagementService = deviceManagementService ?? throw new ArgumentNullException(nameof(deviceManagementService));
+        _openZonesProfiles = openZonesProfiles;
+        _refreshCommand = new RelayCommand(() => _ = RefreshAsync(), () => !IsRefreshing);
+        _openZonesProfilesCommand = new RelayCommand(() => _openZonesProfiles?.Invoke(), () => _openZonesProfiles is not null);
+
+        DeviceRows = [];
+        ZoneOptions = [];
+
+        _refreshTimer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(15)
+        };
+        _refreshTimer.Tick += (_, _) => _ = RefreshAsync();
+        _refreshTimer.Start();
+
+        _configurationSession.ConfigurationChanged += OnConfigurationChanged;
+        RebuildRows(_configurationSession.CurrentConfiguration);
+        _ = RefreshAsync();
     }
 
-    public IReadOnlyList<PersistedDeviceIdentity> Devices { get; }
+    public ObservableCollection<DeviceRowViewModel> DeviceRows { get; }
+
+    public ObservableCollection<ZoneOptionViewModel> ZoneOptions { get; }
+
+    public RelayCommand RefreshCommand => _refreshCommand;
+
+    public RelayCommand OpenZonesProfilesCommand => _openZonesProfilesCommand;
+
+    public bool HasDevices => DeviceRows.Count > 0;
+
+    public bool HasZones => ZoneOptions.Count > 1;
+
+    public int DeviceCount => DeviceRows.Count;
+
+    public int DetectedThisSessionCount => DeviceRows.Count(device => device.IsDetectedThisSession);
+
+    public int UnassignedDeviceCount => DeviceRows.Count(device => !device.IsAssigned);
+
+    public bool IsRefreshing
+    {
+        get => _isRefreshing;
+        private set
+        {
+            if (!SetProperty(ref _isRefreshing, value))
+            {
+                return;
+            }
+
+            _refreshCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    public string DeviceSummary => HasDevices
+        ? $"{DeviceCount} device record(s), {DetectedThisSessionCount} detected now, {UnassignedDeviceCount} unassigned."
+        : "No devices detected or remembered yet.";
+
+    public string ZoneAssignmentHelpText => HasZones
+        ? "Rename devices with app-local aliases and assign them to the zone that should control display switching."
+        : "No zones are configured yet. Add a zone in Zones / Profiles before assigning devices.";
+
+    public string RefreshStatusMessage
+    {
+        get => _refreshStatusMessage ?? "Waiting for the first device snapshot.";
+        private set => SetProperty(ref _refreshStatusMessage, value);
+    }
+
+    public bool RefreshStatusIsError
+    {
+        get => _refreshStatusIsError;
+        private set => SetProperty(ref _refreshStatusIsError, value);
+    }
+
+    public string LastRefreshedText => _lastRefreshedAtUtc.HasValue
+        ? $"Last refreshed {_lastRefreshedAtUtc.Value.ToLocalTime():yyyy-MM-dd HH:mm:ss}"
+        : "No live snapshot yet.";
+
+    private async Task RefreshAsync()
+    {
+        if (IsRefreshing)
+        {
+            return;
+        }
+
+        IsRefreshing = true;
+
+        try
+        {
+            _runtimeDevices = await _snapshotProvider.GetCurrentDevicesAsync().ConfigureAwait(true);
+            _lastRefreshedAtUtc = DateTimeOffset.UtcNow;
+            OnPropertyChanged(nameof(LastRefreshedText));
+
+            RefreshStatusMessage = _runtimeDevices.Count == 0
+                ? "No active keyboards or mice were found in the latest snapshot. Saved mappings stay visible so you can keep managing them."
+                : "Live device snapshot updated.";
+            RefreshStatusIsError = false;
+            RebuildRows(_configurationSession.CurrentConfiguration);
+        }
+        catch (Exception exception)
+        {
+            RefreshStatusMessage = $"Device snapshot failed: {exception.Message}";
+            RefreshStatusIsError = true;
+        }
+        finally
+        {
+            IsRefreshing = false;
+        }
+    }
+
+    private async Task PersistEditAsync(DeviceEditRequest request)
+    {
+        try
+        {
+            await _configurationSession.UpdateAsync(current => current with
+            {
+                DeviceRegistry = _deviceManagementService.ApplyEdits(
+                    current.DeviceRegistry,
+                    request.Entry,
+                    request.FriendlyName,
+                    request.AssignedZoneId,
+                    DateTimeOffset.UtcNow)
+            }).ConfigureAwait(true);
+
+            RefreshStatusMessage = $"Saved changes for '{request.FriendlyName}'.";
+            RefreshStatusIsError = false;
+        }
+        catch (Exception exception)
+        {
+            RefreshStatusMessage = $"Could not save device changes: {exception.Message}";
+            RefreshStatusIsError = true;
+            RebuildRows(_configurationSession.CurrentConfiguration);
+        }
+    }
+
+    private void OnConfigurationChanged(AppConfiguration configuration)
+    {
+        var dispatcher = Application.Current?.Dispatcher;
+        if (dispatcher is null || dispatcher.CheckAccess())
+        {
+            RebuildRows(configuration);
+            return;
+        }
+
+        dispatcher.Invoke(() => RebuildRows(configuration));
+    }
+
+    private void RebuildRows(AppConfiguration configuration)
+    {
+        DeviceRows.Clear();
+        ZoneOptions.Clear();
+
+        ZoneOptions.Add(ZoneOptionViewModel.CreateUnassigned());
+        foreach (var zone in configuration.DeviceRegistry.Zones.OrderBy(zone => zone.Name, StringComparer.CurrentCultureIgnoreCase))
+        {
+            ZoneOptions.Add(new ZoneOptionViewModel(zone));
+        }
+
+        var entries = _deviceManagementService.BuildEntries(configuration.DeviceRegistry, _runtimeDevices);
+        foreach (var entry in entries)
+        {
+            DeviceRows.Add(new DeviceRowViewModel(entry, request => _ = PersistEditAsync(request)));
+        }
+
+        OnPropertyChanged(nameof(HasDevices));
+        OnPropertyChanged(nameof(HasZones));
+        OnPropertyChanged(nameof(DeviceCount));
+        OnPropertyChanged(nameof(DetectedThisSessionCount));
+        OnPropertyChanged(nameof(UnassignedDeviceCount));
+        OnPropertyChanged(nameof(DeviceSummary));
+        OnPropertyChanged(nameof(ZoneAssignmentHelpText));
+    }
+
+    public override void Dispose()
+    {
+        _refreshTimer.Stop();
+        _configurationSession.ConfigurationChanged -= OnConfigurationChanged;
+    }
 }

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/MainWindowViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/MainWindowViewModel.cs
@@ -1,39 +1,59 @@
 using System.Collections.ObjectModel;
 using InputAwareDisplaySwitcher.Core.Application;
-using InputAwareDisplaySwitcher.Core.Domain.Configuration;
 
 namespace InputAwareDisplaySwitcher.App.ViewModels;
 
-public sealed class MainWindowViewModel : ObservableObject
+public sealed class MainWindowViewModel : ObservableObject, IDisposable
 {
     private NavigationItemViewModel? _selectedNavigation;
     private SectionViewModelBase _currentSection;
+    private readonly IReadOnlyList<SectionViewModelBase> _sections;
 
-    public MainWindowViewModel(AppConfiguration configuration, IDiagnosticsService diagnostics, string configurationPath)
+    public MainWindowViewModel(
+        AppConfigurationSession configurationSession,
+        IInputDeviceSnapshotProvider snapshotProvider,
+        DeviceManagementService deviceManagementService,
+        IDiagnosticsService diagnostics,
+        string configurationPath)
     {
-        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(configurationSession);
+        ArgumentNullException.ThrowIfNull(snapshotProvider);
+        ArgumentNullException.ThrowIfNull(deviceManagementService);
         ArgumentNullException.ThrowIfNull(diagnostics);
         ArgumentException.ThrowIfNullOrWhiteSpace(configurationPath);
 
         WindowTitle = "Input Aware Display Switcher";
         ConfigurationPath = configurationPath;
 
-        var devices = new DevicesViewModel(configuration.DeviceRegistry.Devices);
-        var zonesProfiles = new ZonesProfilesViewModel(
-            configuration.DeviceRegistry.Zones,
-            configuration.DeviceRegistry.DisplayProfiles);
-        var rules = new RulesSettingsViewModel(configuration.SwitchingPolicy, configuration.Preferences);
+        var configuration = configurationSession.CurrentConfiguration;
+        var zonesProfiles = new ZonesProfilesViewModel(configurationSession);
+        NavigationItemViewModel? zonesNavigationItem = null;
+        var rules = new RulesSettingsViewModel(
+            configurationSession,
+            configuration.Preferences,
+            configuration.SwitchingPolicy);
+        var devices = new DevicesViewModel(
+            configurationSession,
+            snapshotProvider,
+            deviceManagementService,
+            openZonesProfiles: () => SelectedNavigation = zonesNavigationItem);
         var diagnosticsSection = new DiagnosticsViewModel(diagnostics);
+        _sections = [devices, zonesProfiles, rules, diagnosticsSection];
 
-        NavigationItems = new ObservableCollection<NavigationItemViewModel>
-        {
-            new("Devices", "Persisted device identities and zone assignments.", devices),
-            new("Zones / Profiles", "Logical zones and display profile mappings.", zonesProfiles),
-            new("Rules / Settings", "Switching policy, cooldowns, and lock state.", rules),
-            new("Diagnostics", "Structured runtime and configuration history.", diagnosticsSection)
-        };
+        var devicesNavigationItem = new NavigationItemViewModel("Devices", "Live input devices, aliases, and zone assignments.", devices);
+        zonesNavigationItem = new NavigationItemViewModel("Zones / Profiles", "Logical zones and display profile mappings.", zonesProfiles);
+        var rulesNavigationItem = new NavigationItemViewModel("Rules / Settings", "Automation, cooldowns, and priority behaviour.", rules);
+        var diagnosticsNavigationItem = new NavigationItemViewModel("Diagnostics", "Structured runtime and configuration history.", diagnosticsSection);
 
-        _selectedNavigation = NavigationItems[0];
+        NavigationItems =
+        [
+            devicesNavigationItem,
+            zonesNavigationItem,
+            rulesNavigationItem,
+            diagnosticsNavigationItem
+        ];
+
+        _selectedNavigation = devicesNavigationItem;
         _currentSection = _selectedNavigation.Section;
     }
 
@@ -61,5 +81,13 @@ public sealed class MainWindowViewModel : ObservableObject
     {
         get => _currentSection;
         private set => SetProperty(ref _currentSection, value);
+    }
+
+    public void Dispose()
+    {
+        foreach (var section in _sections)
+        {
+            section.Dispose();
+        }
     }
 }

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/PriorityModeOptionViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/PriorityModeOptionViewModel.cs
@@ -1,0 +1,19 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.App.ViewModels;
+
+public sealed class PriorityModeOptionViewModel
+{
+    public PriorityModeOptionViewModel(PriorityMode value, string label, string description)
+    {
+        Value = value;
+        Label = label;
+        Description = description;
+    }
+
+    public PriorityMode Value { get; }
+
+    public string Label { get; }
+
+    public string Description { get; }
+}

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/RelayCommand.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/RelayCommand.cs
@@ -1,0 +1,32 @@
+using System.Windows.Input;
+
+namespace InputAwareDisplaySwitcher.App.ViewModels;
+
+public sealed class RelayCommand : ICommand
+{
+    private readonly Action _execute;
+    private readonly Func<bool>? _canExecute;
+
+    public RelayCommand(Action execute, Func<bool>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        return _canExecute?.Invoke() ?? true;
+    }
+
+    public void Execute(object? parameter)
+    {
+        _execute();
+    }
+
+    public void NotifyCanExecuteChanged()
+    {
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/RulesSettingsViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/RulesSettingsViewModel.cs
@@ -1,3 +1,4 @@
+using InputAwareDisplaySwitcher.Core.Application;
 using InputAwareDisplaySwitcher.Core.Domain.Configuration;
 using InputAwareDisplaySwitcher.Core.Domain.Switching;
 
@@ -5,20 +6,310 @@ namespace InputAwareDisplaySwitcher.App.ViewModels;
 
 public sealed class RulesSettingsViewModel : SectionViewModelBase
 {
-    public RulesSettingsViewModel(SwitchingPolicy policy, AppPreferences preferences)
+    private const int MaximumSeconds = 86400;
+
+    private readonly AppConfigurationSession _configurationSession;
+    private readonly RelayCommand _saveCommand;
+    private readonly RelayCommand _restoreDefaultsCommand;
+    private AppPreferences _preferences;
+    private bool _automationEnabled;
+    private string _cooldownSecondsText = string.Empty;
+    private string _recentActivityThresholdSecondsText = string.Empty;
+    private PriorityModeOptionViewModel? _selectedPriorityMode;
+    private bool _manualLockStopsSwitching;
+    private bool _allowSameProfileRefresh;
+    private string? _cooldownError;
+    private string? _recentActivityThresholdError;
+    private bool _isSaving;
+    private string? _saveStatusMessage;
+    private bool _saveStatusIsError;
+
+    public RulesSettingsViewModel(
+        AppConfigurationSession configurationSession,
+        AppPreferences preferences,
+        SwitchingPolicy policy)
         : base("Rules / Settings", "Switching policy, cooldowns, and operator preferences.")
     {
-        Cooldown = policy.Cooldown;
-        ManualLockStopsSwitching = policy.ManualLockStopsSwitching;
-        AllowSameProfileRefresh = policy.AllowSameProfileRefresh;
-        IsManualSwitchingLocked = preferences.IsManualSwitchingLocked;
+        _configurationSession = configurationSession ?? throw new ArgumentNullException(nameof(configurationSession));
+        _preferences = preferences ?? new AppPreferences();
+        _saveCommand = new RelayCommand(() => _ = SaveAsync(), CanSave);
+        _restoreDefaultsCommand = new RelayCommand(RestoreDefaults, () => !IsSaving);
+        PriorityModes =
+        [
+            new PriorityModeOptionViewModel(
+                PriorityMode.MostRecentInputWins,
+                "Most recent input wins",
+                "Switch immediately to the latest mapped device, subject to cooldown and lock rules."),
+            new PriorityModeOptionViewModel(
+                PriorityMode.PreferHigherPriorityZone,
+                "Keep a higher-priority zone active briefly",
+                "If the current zone has a higher priority, keep it active during the recent activity window before allowing a lower-priority takeover.")
+        ];
+
+        ApplyPolicy(policy ?? new SwitchingPolicy());
+        _configurationSession.ConfigurationChanged += OnConfigurationChanged;
     }
 
-    public TimeSpan Cooldown { get; }
+    public bool AutomationEnabled
+    {
+        get => _automationEnabled;
+        set
+        {
+            if (!SetProperty(ref _automationEnabled, value))
+            {
+                return;
+            }
 
-    public bool ManualLockStopsSwitching { get; }
+            OnFormStateChanged();
+        }
+    }
 
-    public bool AllowSameProfileRefresh { get; }
+    public string CooldownSecondsText
+    {
+        get => _cooldownSecondsText;
+        set
+        {
+            if (!SetProperty(ref _cooldownSecondsText, value))
+            {
+                return;
+            }
 
-    public bool IsManualSwitchingLocked { get; }
+            CooldownError = ValidateSeconds(value, "Cooldown");
+            OnFormStateChanged();
+        }
+    }
+
+    public string RecentActivityThresholdSecondsText
+    {
+        get => _recentActivityThresholdSecondsText;
+        set
+        {
+            if (!SetProperty(ref _recentActivityThresholdSecondsText, value))
+            {
+                return;
+            }
+
+            RecentActivityThresholdError = ValidateSeconds(value, "Recent activity window");
+            OnFormStateChanged();
+        }
+    }
+
+    public IReadOnlyList<PriorityModeOptionViewModel> PriorityModes { get; }
+
+    public PriorityModeOptionViewModel? SelectedPriorityMode
+    {
+        get => _selectedPriorityMode;
+        set
+        {
+            if (!SetProperty(ref _selectedPriorityMode, value))
+            {
+                return;
+            }
+
+            OnFormStateChanged();
+        }
+    }
+
+    public bool ManualLockStopsSwitching
+    {
+        get => _manualLockStopsSwitching;
+        set
+        {
+            if (!SetProperty(ref _manualLockStopsSwitching, value))
+            {
+                return;
+            }
+
+            OnFormStateChanged();
+        }
+    }
+
+    public bool AllowSameProfileRefresh
+    {
+        get => _allowSameProfileRefresh;
+        set
+        {
+            if (!SetProperty(ref _allowSameProfileRefresh, value))
+            {
+                return;
+            }
+
+            OnFormStateChanged();
+        }
+    }
+
+    public string? CooldownError
+    {
+        get => _cooldownError;
+        private set => SetProperty(ref _cooldownError, value);
+    }
+
+    public string? RecentActivityThresholdError
+    {
+        get => _recentActivityThresholdError;
+        private set => SetProperty(ref _recentActivityThresholdError, value);
+    }
+
+    public bool HasValidationErrors => !string.IsNullOrWhiteSpace(CooldownError) || !string.IsNullOrWhiteSpace(RecentActivityThresholdError);
+
+    public bool IsSaving
+    {
+        get => _isSaving;
+        private set
+        {
+            if (!SetProperty(ref _isSaving, value))
+            {
+                return;
+            }
+
+            NotifyCommandStateChanged();
+        }
+    }
+
+    public string? SaveStatusMessage
+    {
+        get => _saveStatusMessage;
+        private set => SetProperty(ref _saveStatusMessage, value);
+    }
+
+    public bool SaveStatusIsError
+    {
+        get => _saveStatusIsError;
+        private set => SetProperty(ref _saveStatusIsError, value);
+    }
+
+    public RelayCommand SaveCommand => _saveCommand;
+
+    public RelayCommand RestoreDefaultsCommand => _restoreDefaultsCommand;
+
+    public bool CanSave()
+    {
+        return !IsSaving
+            && !HasValidationErrors
+            && SelectedPriorityMode is not null;
+    }
+
+    private void ApplyPolicy(SwitchingPolicy policy)
+    {
+        _manualLockStopsSwitching = policy.ManualLockStopsSwitching;
+        _allowSameProfileRefresh = policy.AllowSameProfileRefresh;
+
+        AutomationEnabled = policy.AutomationEnabled;
+        CooldownSecondsText = ((int)policy.Cooldown.TotalSeconds).ToString();
+        RecentActivityThresholdSecondsText = ((int)policy.RecentActivityThreshold.TotalSeconds).ToString();
+        SelectedPriorityMode = PriorityModes.FirstOrDefault(option => option.Value == policy.PriorityMode) ?? PriorityModes[0];
+        OnPropertyChanged(nameof(ManualLockStopsSwitching));
+        OnPropertyChanged(nameof(AllowSameProfileRefresh));
+        SaveStatusMessage = null;
+        SaveStatusIsError = false;
+    }
+
+    private void RestoreDefaults()
+    {
+        ApplyPolicy(new SwitchingPolicy());
+        SaveStatusMessage = "Defaults restored in the form. Choose Save settings to write them to config.";
+        SaveStatusIsError = false;
+    }
+
+    private async Task SaveAsync()
+    {
+        if (!CanSave())
+        {
+            return;
+        }
+
+        IsSaving = true;
+        SaveStatusMessage = "Saving rules to configuration...";
+        SaveStatusIsError = false;
+
+        try
+        {
+            var policy = BuildPolicy();
+            await _configurationSession.UpdateAsync(current => current with
+            {
+                SwitchingPolicy = policy,
+                Preferences = _preferences
+            }).ConfigureAwait(true);
+
+            SaveStatusMessage = "Rules and settings saved.";
+            SaveStatusIsError = false;
+        }
+        catch (Exception exception)
+        {
+            SaveStatusMessage = $"Save failed: {exception.Message}";
+            SaveStatusIsError = true;
+        }
+        finally
+        {
+            IsSaving = false;
+        }
+    }
+
+    private SwitchingPolicy BuildPolicy()
+    {
+        return new SwitchingPolicy
+        {
+            AutomationEnabled = AutomationEnabled,
+            Cooldown = TimeSpan.FromSeconds(ParseSeconds(CooldownSecondsText)),
+            RecentActivityThreshold = TimeSpan.FromSeconds(ParseSeconds(RecentActivityThresholdSecondsText)),
+            PriorityMode = SelectedPriorityMode?.Value ?? PriorityMode.MostRecentInputWins,
+            ManualLockStopsSwitching = ManualLockStopsSwitching,
+            AllowSameProfileRefresh = AllowSameProfileRefresh
+        };
+    }
+
+    private static string? ValidateSeconds(string value, string label)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return $"{label} is required.";
+        }
+
+        if (!int.TryParse(value, out var seconds))
+        {
+            return $"{label} must be a whole number of seconds.";
+        }
+
+        if (seconds < 0)
+        {
+            return $"{label} cannot be negative.";
+        }
+
+        if (seconds > MaximumSeconds)
+        {
+            return $"{label} must stay at or below {MaximumSeconds} seconds.";
+        }
+
+        return null;
+    }
+
+    private static int ParseSeconds(string value)
+    {
+        return int.TryParse(value, out var seconds)
+            ? seconds
+            : 0;
+    }
+
+    private void OnFormStateChanged()
+    {
+        OnPropertyChanged(nameof(HasValidationErrors));
+        NotifyCommandStateChanged();
+    }
+
+    private void NotifyCommandStateChanged()
+    {
+        _saveCommand.NotifyCanExecuteChanged();
+        _restoreDefaultsCommand.NotifyCanExecuteChanged();
+    }
+
+    private void OnConfigurationChanged(AppConfiguration configuration)
+    {
+        _preferences = configuration.Preferences;
+        ApplyPolicy(configuration.SwitchingPolicy);
+    }
+
+    public override void Dispose()
+    {
+        _configurationSession.ConfigurationChanged -= OnConfigurationChanged;
+    }
 }

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/SectionViewModelBase.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/SectionViewModelBase.cs
@@ -1,6 +1,6 @@
 namespace InputAwareDisplaySwitcher.App.ViewModels;
 
-public abstract class SectionViewModelBase
+public abstract class SectionViewModelBase : ObservableObject, IDisposable
 {
     protected SectionViewModelBase(string title, string description)
     {
@@ -11,4 +11,8 @@ public abstract class SectionViewModelBase
     public string Title { get; }
 
     public string Description { get; }
+
+    public virtual void Dispose()
+    {
+    }
 }

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/ZoneOptionViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/ZoneOptionViewModel.cs
@@ -1,0 +1,33 @@
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.App.ViewModels;
+
+public sealed class ZoneOptionViewModel
+{
+    public static ZoneOptionViewModel CreateUnassigned()
+    {
+        return new ZoneOptionViewModel(null, "Unassigned", isEnabled: true);
+    }
+
+    public ZoneOptionViewModel(string? zoneId, string displayName, bool isEnabled)
+    {
+        ZoneId = zoneId;
+        DisplayName = displayName;
+        IsEnabled = isEnabled;
+    }
+
+    public ZoneOptionViewModel(ZoneDefinition zone)
+    {
+        ArgumentNullException.ThrowIfNull(zone);
+
+        ZoneId = zone.ZoneId;
+        DisplayName = zone.IsEnabled ? zone.Name : $"{zone.Name} (disabled)";
+        IsEnabled = zone.IsEnabled;
+    }
+
+    public string? ZoneId { get; }
+
+    public string DisplayName { get; }
+
+    public bool IsEnabled { get; }
+}

--- a/src/InputAwareDisplaySwitcher.App/ViewModels/ZonesProfilesViewModel.cs
+++ b/src/InputAwareDisplaySwitcher.App/ViewModels/ZonesProfilesViewModel.cs
@@ -1,3 +1,6 @@
+using System.Collections.ObjectModel;
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Configuration;
 using InputAwareDisplaySwitcher.Core.Domain.Profiles;
 using InputAwareDisplaySwitcher.Core.Domain.Zones;
 
@@ -5,16 +8,254 @@ namespace InputAwareDisplaySwitcher.App.ViewModels;
 
 public sealed class ZonesProfilesViewModel : SectionViewModelBase
 {
-    public ZonesProfilesViewModel(
-        IReadOnlyList<ZoneDefinition> zones,
-        IReadOnlyList<DisplayProfile> profiles)
+    private readonly AppConfigurationSession _configurationSession;
+    private readonly RelayCommand _addProfileCommand;
+    private readonly RelayCommand _addZoneCommand;
+    private string _newProfileName = string.Empty;
+    private string _newProfileDescription = string.Empty;
+    private DisplayProfileIntentKind _newProfileIntentKind = DisplayProfileIntentKind.ExternalOnly;
+    private string _newZoneName = string.Empty;
+    private string _newZoneDescription = string.Empty;
+    private string _newZonePriorityText = "0";
+    private ZoneOptionViewModel? _selectedProfileForZone;
+    private string? _statusMessage;
+    private bool _statusIsError;
+
+    public ZonesProfilesViewModel(AppConfigurationSession configurationSession)
         : base("Zones / Profiles", "Logical zones and the display intents they resolve to.")
     {
-        Zones = zones;
-        Profiles = profiles;
+        _configurationSession = configurationSession ?? throw new ArgumentNullException(nameof(configurationSession));
+        _addProfileCommand = new RelayCommand(() => _ = AddProfileAsync());
+        _addZoneCommand = new RelayCommand(() => _ = AddZoneAsync());
+
+        Zones = [];
+        Profiles = [];
+        ProfileOptions = [];
+        ProfileIntentKinds = Enum.GetValues<DisplayProfileIntentKind>();
+
+        _configurationSession.ConfigurationChanged += OnConfigurationChanged;
+        ApplyConfiguration(_configurationSession.CurrentConfiguration);
     }
 
-    public IReadOnlyList<ZoneDefinition> Zones { get; }
+    public ObservableCollection<ZoneDefinition> Zones { get; }
 
-    public IReadOnlyList<DisplayProfile> Profiles { get; }
+    public ObservableCollection<DisplayProfile> Profiles { get; }
+
+    public ObservableCollection<ZoneOptionViewModel> ProfileOptions { get; }
+
+    public IReadOnlyList<DisplayProfileIntentKind> ProfileIntentKinds { get; }
+
+    public RelayCommand AddProfileCommand => _addProfileCommand;
+
+    public RelayCommand AddZoneCommand => _addZoneCommand;
+
+    public string NewProfileName
+    {
+        get => _newProfileName;
+        set => SetProperty(ref _newProfileName, value);
+    }
+
+    public string NewProfileDescription
+    {
+        get => _newProfileDescription;
+        set => SetProperty(ref _newProfileDescription, value);
+    }
+
+    public DisplayProfileIntentKind NewProfileIntentKind
+    {
+        get => _newProfileIntentKind;
+        set => SetProperty(ref _newProfileIntentKind, value);
+    }
+
+    public string NewZoneName
+    {
+        get => _newZoneName;
+        set => SetProperty(ref _newZoneName, value);
+    }
+
+    public string NewZoneDescription
+    {
+        get => _newZoneDescription;
+        set => SetProperty(ref _newZoneDescription, value);
+    }
+
+    public string NewZonePriorityText
+    {
+        get => _newZonePriorityText;
+        set => SetProperty(ref _newZonePriorityText, value);
+    }
+
+    public ZoneOptionViewModel? SelectedProfileForZone
+    {
+        get => _selectedProfileForZone;
+        set => SetProperty(ref _selectedProfileForZone, value);
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage ?? "Add at least one profile and zone so device assignments have somewhere to point.";
+        private set => SetProperty(ref _statusMessage, value);
+    }
+
+    public bool StatusIsError
+    {
+        get => _statusIsError;
+        private set => SetProperty(ref _statusIsError, value);
+    }
+
+    public bool HasProfiles => Profiles.Count > 0;
+
+    private async Task AddProfileAsync()
+    {
+        if (string.IsNullOrWhiteSpace(NewProfileName))
+        {
+            StatusMessage = "Profile name is required.";
+            StatusIsError = true;
+            return;
+        }
+
+        var profile = new DisplayProfile
+        {
+            DisplayProfileId = CreateSlug(NewProfileName, Profiles.Select(existing => existing.DisplayProfileId)),
+            Name = NewProfileName.Trim(),
+            Description = string.IsNullOrWhiteSpace(NewProfileDescription) ? null : NewProfileDescription.Trim(),
+            IntentKind = NewProfileIntentKind
+        };
+
+        await _configurationSession.UpdateAsync(current => current with
+        {
+            DeviceRegistry = current.DeviceRegistry with
+            {
+                DisplayProfiles = current.DeviceRegistry.DisplayProfiles
+                    .Append(profile)
+                    .ToList()
+            }
+        }).ConfigureAwait(true);
+
+        NewProfileName = string.Empty;
+        NewProfileDescription = string.Empty;
+        NewProfileIntentKind = DisplayProfileIntentKind.ExternalOnly;
+        StatusMessage = $"Added profile '{profile.Name}'.";
+        StatusIsError = false;
+    }
+
+    private async Task AddZoneAsync()
+    {
+        if (!HasProfiles)
+        {
+            StatusMessage = "Add a display profile first, then create a zone that points to it.";
+            StatusIsError = true;
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(NewZoneName))
+        {
+            StatusMessage = "Zone name is required.";
+            StatusIsError = true;
+            return;
+        }
+
+        if (SelectedProfileForZone?.ZoneId is null)
+        {
+            StatusMessage = "Choose the display profile this zone should resolve to.";
+            StatusIsError = true;
+            return;
+        }
+
+        if (!int.TryParse(NewZonePriorityText, out var priority) || priority < 0)
+        {
+            StatusMessage = "Zone priority must be a non-negative whole number.";
+            StatusIsError = true;
+            return;
+        }
+
+        var zone = new ZoneDefinition
+        {
+            ZoneId = CreateSlug(NewZoneName, Zones.Select(existing => existing.ZoneId)),
+            Name = NewZoneName.Trim(),
+            PreferredDisplayProfileId = SelectedProfileForZone.ZoneId,
+            Priority = priority,
+            Description = string.IsNullOrWhiteSpace(NewZoneDescription) ? null : NewZoneDescription.Trim()
+        };
+
+        await _configurationSession.UpdateAsync(current => current with
+        {
+            DeviceRegistry = current.DeviceRegistry with
+            {
+                Zones = current.DeviceRegistry.Zones
+                    .Append(zone)
+                    .ToList()
+            }
+        }).ConfigureAwait(true);
+
+        NewZoneName = string.Empty;
+        NewZoneDescription = string.Empty;
+        NewZonePriorityText = "0";
+        SelectedProfileForZone = ProfileOptions.FirstOrDefault();
+        StatusMessage = $"Added zone '{zone.Name}'.";
+        StatusIsError = false;
+    }
+
+    private void ApplyConfiguration(AppConfiguration configuration)
+    {
+        Zones.Clear();
+        foreach (var zone in configuration.DeviceRegistry.Zones.OrderBy(zone => zone.Name, StringComparer.CurrentCultureIgnoreCase))
+        {
+            Zones.Add(zone);
+        }
+
+        Profiles.Clear();
+        foreach (var profile in configuration.DeviceRegistry.DisplayProfiles.OrderBy(profile => profile.Name, StringComparer.CurrentCultureIgnoreCase))
+        {
+            Profiles.Add(profile);
+        }
+
+        ProfileOptions.Clear();
+        foreach (var profile in Profiles)
+        {
+            ProfileOptions.Add(new ZoneOptionViewModel(profile.DisplayProfileId, profile.Name, profile.IsEnabled));
+        }
+
+        if (SelectedProfileForZone is null || ProfileOptions.All(option => option.ZoneId != SelectedProfileForZone.ZoneId))
+        {
+            SelectedProfileForZone = ProfileOptions.FirstOrDefault();
+        }
+
+        OnPropertyChanged(nameof(HasProfiles));
+    }
+
+    private static string CreateSlug(string label, IEnumerable<string> existingValues)
+    {
+        var slug = new string(label
+            .Trim()
+            .ToLowerInvariant()
+            .Select(character => char.IsLetterOrDigit(character) ? character : '-')
+            .ToArray())
+            .Trim('-');
+
+        if (string.IsNullOrWhiteSpace(slug))
+        {
+            slug = "item";
+        }
+
+        var existing = new HashSet<string>(existingValues, StringComparer.OrdinalIgnoreCase);
+        var candidate = slug;
+        var suffix = 2;
+        while (existing.Contains(candidate))
+        {
+            candidate = $"{slug}-{suffix++}";
+        }
+
+        return candidate;
+    }
+
+    private void OnConfigurationChanged(AppConfiguration configuration)
+    {
+        ApplyConfiguration(configuration);
+    }
+
+    public override void Dispose()
+    {
+        _configurationSession.ConfigurationChanged -= OnConfigurationChanged;
+    }
 }

--- a/src/InputAwareDisplaySwitcher.App/Views/DevicesView.xaml
+++ b/src/InputAwareDisplaySwitcher.App/Views/DevicesView.xaml
@@ -4,38 +4,259 @@
   <Grid>
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
+      <RowDefinition Height="Auto" />
       <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
 
-    <TextBlock Margin="0,0,0,12"
-               Foreground="#FF4B5563"
-               TextWrapping="Wrap"
-               Text="This section will become the main device registry editor. For now it shows the persisted device records loaded from configuration." />
+    <Grid Margin="0,0,0,16">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*" />
+        <ColumnDefinition Width="Auto" />
+      </Grid.ColumnDefinitions>
 
-    <DataGrid Grid.Row="1"
-              ItemsSource="{Binding Devices}"
-              AutoGenerateColumns="False"
-              CanUserAddRows="False"
-              CanUserDeleteRows="False"
-              IsReadOnly="True"
-              HeadersVisibility="Column">
-      <DataGrid.Columns>
-        <DataGridTextColumn Header="Friendly Name"
-                            Binding="{Binding FriendlyName}"
-                            Width="2*" />
-        <DataGridTextColumn Header="Kind"
-                            Binding="{Binding DeviceKind}"
-                            Width="*" />
-        <DataGridTextColumn Header="Assigned Zone"
-                            Binding="{Binding AssignedZoneId}"
-                            Width="*" />
-        <DataGridTextColumn Header="Persistence Key"
-                            Binding="{Binding PreferredPersistenceKey}"
-                            Width="2*" />
-        <DataGridCheckBoxColumn Header="Enabled"
-                                Binding="{Binding IsEnabled}"
-                                Width="90" />
-      </DataGrid.Columns>
-    </DataGrid>
+      <StackPanel>
+        <TextBlock Foreground="#FF4B5563"
+                   TextWrapping="Wrap"
+                   Text="Inspect live input devices, set app-local aliases, and assign each one to the zone that should influence display switching. Aliases are stored only in this app and do not rename the hardware in Windows." />
+        <TextBlock Margin="0,10,0,0"
+                   Foreground="#FF1F2937"
+                   FontWeight="SemiBold"
+                   Text="{Binding DeviceSummary}" />
+        <TextBlock Margin="0,6,0,0"
+                   Foreground="#FF6B7280"
+                   TextWrapping="Wrap"
+                   Text="{Binding ZoneAssignmentHelpText}" />
+        <TextBlock Margin="0,6,0,0"
+                   Foreground="#FF6B7280"
+                   Text="{Binding LastRefreshedText}" />
+      </StackPanel>
+
+      <StackPanel Grid.Column="1"
+                  Orientation="Horizontal"
+                  VerticalAlignment="Top">
+        <Button Margin="0,0,8,0"
+                Padding="14,8"
+                Command="{Binding OpenZonesProfilesCommand}"
+                Content="Open Zones / Profiles" />
+        <Button Padding="14,8"
+                Command="{Binding RefreshCommand}"
+                Content="Refresh devices" />
+      </StackPanel>
+    </Grid>
+
+    <Border Grid.Row="1"
+            Margin="0,0,0,16"
+            Padding="12"
+            Background="#FFF9FAFB"
+            BorderBrush="#FFE5E7EB"
+            BorderThickness="1"
+            CornerRadius="10">
+      <TextBlock Foreground="#FF6B7280"
+                 TextWrapping="Wrap"
+                 Text="Unassigned devices stay visible until you map them. Devices that only expose a session handle are shown for diagnostics, but their alias and zone controls stay disabled until stronger identity evidence is available." />
+    </Border>
+
+    <Grid Grid.Row="2">
+      <TextBlock HorizontalAlignment="Center"
+                 VerticalAlignment="Center"
+                 FontSize="18"
+                 FontWeight="SemiBold"
+                 Foreground="#FF6B7280"
+                 Text="No devices detected or remembered yet.">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock">
+            <Setter Property="Visibility"
+                    Value="Collapsed" />
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasDevices}"
+                           Value="False">
+                <Setter Property="Visibility"
+                        Value="Visible" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+
+      <DataGrid ItemsSource="{Binding DeviceRows}"
+                AutoGenerateColumns="False"
+                CanUserAddRows="False"
+                CanUserDeleteRows="False"
+                IsReadOnly="False"
+                HeadersVisibility="Column">
+        <DataGrid.Style>
+          <Style TargetType="DataGrid">
+            <Setter Property="Visibility"
+                    Value="Visible" />
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding HasDevices}"
+                           Value="False">
+                <Setter Property="Visibility"
+                        Value="Collapsed" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </DataGrid.Style>
+        <DataGrid.Columns>
+          <DataGridTextColumn Header="Device Type"
+                              Binding="{Binding DeviceKindDisplay}"
+                              IsReadOnly="True"
+                              Width="120" />
+
+          <DataGridTextColumn Header="Availability"
+                              Binding="{Binding AvailabilityStatus}"
+                              IsReadOnly="True"
+                              Width="120" />
+
+          <DataGridTemplateColumn Header="Friendly Name"
+                                  Width="220">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <TextBox Text="{Binding FriendlyName, Mode=TwoWay, UpdateSourceTrigger=LostFocus}">
+                  <TextBox.Style>
+                    <Style TargetType="TextBox">
+                      <Setter Property="IsEnabled"
+                              Value="True" />
+                      <Style.Triggers>
+                        <DataTrigger Binding="{Binding CanEdit}"
+                                     Value="False">
+                          <Setter Property="IsEnabled"
+                                  Value="False" />
+                        </DataTrigger>
+                      </Style.Triggers>
+                    </Style>
+                  </TextBox.Style>
+                </TextBox>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+
+          <DataGridTemplateColumn Header="Status"
+                                  Width="130">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <Border Padding="8,3"
+                        CornerRadius="999"
+                        HorizontalAlignment="Left">
+                  <Border.Style>
+                    <Style TargetType="Border">
+                      <Setter Property="Background"
+                              Value="#FFFDE68A" />
+                      <Style.Triggers>
+                        <DataTrigger Binding="{Binding IsAssigned}"
+                                     Value="True">
+                          <Setter Property="Background"
+                                  Value="#FFBBF7D0" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding AssignmentStatus}"
+                                     Value="Zone missing">
+                          <Setter Property="Background"
+                                  Value="#FFFED7AA" />
+                        </DataTrigger>
+                      </Style.Triggers>
+                    </Style>
+                  </Border.Style>
+                  <TextBlock FontWeight="SemiBold"
+                             Text="{Binding AssignmentStatus}" />
+                </Border>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+
+          <DataGridTemplateColumn Header="Assigned Zone"
+                                  Width="220">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <ComboBox ItemsSource="{Binding DataContext.ZoneOptions, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                          DisplayMemberPath="DisplayName"
+                          SelectedValuePath="ZoneId"
+                          SelectedValue="{Binding AssignedZoneId, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                  <ComboBox.Style>
+                    <Style TargetType="ComboBox">
+                      <Setter Property="IsEnabled"
+                              Value="True" />
+                      <Style.Triggers>
+                        <DataTrigger Binding="{Binding CanEdit}"
+                                     Value="False">
+                          <Setter Property="IsEnabled"
+                                  Value="False" />
+                        </DataTrigger>
+                        <DataTrigger Binding="{Binding DataContext.HasZones, RelativeSource={RelativeSource AncestorType=DataGrid}}"
+                                     Value="False">
+                          <Setter Property="IsEnabled"
+                                  Value="False" />
+                        </DataTrigger>
+                      </Style.Triggers>
+                    </Style>
+                  </ComboBox.Style>
+                </ComboBox>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+
+          <DataGridTextColumn Header="Zone Summary"
+                              Binding="{Binding AssignedZoneDisplayName}"
+                              IsReadOnly="True"
+                              Width="170" />
+
+          <DataGridTextColumn Header="Stable Identity"
+                              Binding="{Binding StableIdentitySummary}"
+                              IsReadOnly="True"
+                              Width="3*" />
+
+          <DataGridTemplateColumn Header="Metadata"
+                                  Width="2*">
+            <DataGridTemplateColumn.CellTemplate>
+              <DataTemplate>
+                <StackPanel>
+                  <TextBlock TextWrapping="Wrap"
+                             Text="{Binding MetadataSummary}" />
+                  <TextBlock Margin="0,4,0,0"
+                             Foreground="#FFB45309"
+                             TextWrapping="Wrap"
+                             Text="{Binding PersistenceWarning}" />
+                </StackPanel>
+              </DataTemplate>
+            </DataGridTemplateColumn.CellTemplate>
+          </DataGridTemplateColumn>
+
+          <DataGridTextColumn Header="Last Seen"
+                              Binding="{Binding LastSeenDisplay}"
+                              IsReadOnly="True"
+                              Width="140" />
+
+          <DataGridTextColumn Header="State"
+                              Binding="{Binding EnabledState}"
+                              IsReadOnly="True"
+                              Width="90" />
+        </DataGrid.Columns>
+      </DataGrid>
+    </Grid>
+
+    <Border Grid.Row="3"
+            Margin="0,16,0,0"
+            Padding="14"
+            Background="#FFF8FAFC"
+            BorderBrush="#FFE5E7EB"
+            BorderThickness="1"
+            CornerRadius="10">
+      <TextBlock TextWrapping="Wrap"
+                 Text="{Binding RefreshStatusMessage}">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock">
+            <Setter Property="Foreground"
+                    Value="#FF4B5563" />
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding RefreshStatusIsError}"
+                           Value="True">
+                <Setter Property="Foreground"
+                        Value="#FFB91C1C" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/InputAwareDisplaySwitcher.App/Views/RulesSettingsView.xaml
+++ b/src/InputAwareDisplaySwitcher.App/Views/RulesSettingsView.xaml
@@ -3,80 +3,164 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
   <ScrollViewer VerticalScrollBarVisibility="Auto">
     <StackPanel>
-      <TextBlock Margin="0,0,0,12"
+      <TextBlock Margin="0,0,0,16"
                  Foreground="#FF4B5563"
                  TextWrapping="Wrap"
-                 Text="This section is the placeholder for later editing of switching rules and operator controls. The values below come from the configuration model now." />
+                 Text="Tune the safety rails for automatic switching. These values are stored in the shared JSON configuration and are validated before saving." />
 
-      <WrapPanel>
-        <Border Width="220"
-                Margin="0,0,12,12"
-                Padding="16"
-                Background="#FFF9FAFB"
-                BorderBrush="#FFE5E7EB"
-                BorderThickness="1"
-                CornerRadius="10">
-          <StackPanel>
-            <TextBlock Foreground="#FF6B7280"
-                       Text="Cooldown" />
-            <TextBlock Margin="0,6,0,0"
-                       FontSize="20"
-                       FontWeight="SemiBold"
-                       Text="{Binding Cooldown}" />
-          </StackPanel>
-        </Border>
+      <Border Margin="0,0,0,16"
+              Padding="18"
+              Background="#FFF9FAFB"
+              BorderBrush="#FFE5E7EB"
+              BorderThickness="1"
+              CornerRadius="12">
+        <StackPanel>
+          <TextBlock FontSize="18"
+                     FontWeight="SemiBold"
+                     Text="Automation" />
+          <TextBlock Margin="0,6,0,0"
+                     Foreground="#FF4B5563"
+                     TextWrapping="Wrap"
+                     Text="Turn automatic switching on or off without removing your saved device and zone mappings." />
+          <CheckBox Margin="0,14,0,0"
+                    IsChecked="{Binding AutomationEnabled}"
+                    Content="Enable automatic display switching" />
+        </StackPanel>
+      </Border>
 
-        <Border Width="220"
-                Margin="0,0,12,12"
-                Padding="16"
-                Background="#FFF9FAFB"
-                BorderBrush="#FFE5E7EB"
-                BorderThickness="1"
-                CornerRadius="10">
-          <StackPanel>
-            <TextBlock Foreground="#FF6B7280"
-                       Text="Manual Lock Stops Switching" />
-            <TextBlock Margin="0,6,0,0"
-                       FontSize="20"
-                       FontWeight="SemiBold"
-                       Text="{Binding ManualLockStopsSwitching}" />
-          </StackPanel>
-        </Border>
+      <Border Margin="0,0,0,16"
+              Padding="18"
+              Background="#FFF9FAFB"
+              BorderBrush="#FFE5E7EB"
+              BorderThickness="1"
+              CornerRadius="12">
+        <StackPanel>
+          <TextBlock FontSize="18"
+                     FontWeight="SemiBold"
+                     Text="Cooldown &amp; Activity Windows" />
+          <TextBlock Margin="0,6,0,0"
+                     Foreground="#FF4B5563"
+                     TextWrapping="Wrap"
+                     Text="Use short time windows to prevent rapid back-and-forth switching when devices wake up or multiple zones are active close together." />
 
-        <Border Width="220"
-                Margin="0,0,12,12"
-                Padding="16"
-                Background="#FFF9FAFB"
-                BorderBrush="#FFE5E7EB"
-                BorderThickness="1"
-                CornerRadius="10">
-          <StackPanel>
-            <TextBlock Foreground="#FF6B7280"
-                       Text="Allow Same Profile Refresh" />
-            <TextBlock Margin="0,6,0,0"
-                       FontSize="20"
+          <Grid Margin="0,16,0,0">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="240" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center"
                        FontWeight="SemiBold"
-                       Text="{Binding AllowSameProfileRefresh}" />
-          </StackPanel>
-        </Border>
+                       Text="Cooldown (seconds)" />
+            <StackPanel Grid.Column="1">
+              <TextBox Width="180"
+                       HorizontalAlignment="Left"
+                       Text="{Binding CooldownSecondsText, UpdateSourceTrigger=PropertyChanged}" />
+              <TextBlock Margin="0,6,0,0"
+                         Foreground="#FF6B7280"
+                         TextWrapping="Wrap"
+                         Text="Set to 0 to remove the post-switch pause. Higher values are safer when inputs bounce between rooms." />
+              <TextBlock Margin="0,6,0,0"
+                         Foreground="#FFB91C1C"
+                         Text="{Binding CooldownError}" />
+            </StackPanel>
+          </Grid>
 
-        <Border Width="220"
-                Margin="0,0,12,12"
-                Padding="16"
-                Background="#FFF9FAFB"
-                BorderBrush="#FFE5E7EB"
-                BorderThickness="1"
-                CornerRadius="10">
-          <StackPanel>
-            <TextBlock Foreground="#FF6B7280"
-                       Text="Current Manual Lock Preference" />
-            <TextBlock Margin="0,6,0,0"
-                       FontSize="20"
+          <Grid Margin="0,18,0,0">
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition Width="240" />
+              <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <TextBlock VerticalAlignment="Center"
                        FontWeight="SemiBold"
-                       Text="{Binding IsManualSwitchingLocked}" />
+                       Text="Recent activity window (seconds)" />
+            <StackPanel Grid.Column="1">
+              <TextBox Width="180"
+                       HorizontalAlignment="Left"
+                       Text="{Binding RecentActivityThresholdSecondsText, UpdateSourceTrigger=PropertyChanged}" />
+              <TextBlock Margin="0,6,0,0"
+                         Foreground="#FF6B7280"
+                         TextWrapping="Wrap"
+                         Text="When priority handling is enabled, this is how long the current zone is considered recently active after a successful switch." />
+              <TextBlock Margin="0,6,0,0"
+                         Foreground="#FFB91C1C"
+                         Text="{Binding RecentActivityThresholdError}" />
+            </StackPanel>
+          </Grid>
+        </StackPanel>
+      </Border>
+
+      <Border Margin="0,0,0,16"
+              Padding="18"
+              Background="#FFF9FAFB"
+              BorderBrush="#FFE5E7EB"
+              BorderThickness="1"
+              CornerRadius="12">
+        <StackPanel>
+          <TextBlock FontSize="18"
+                     FontWeight="SemiBold"
+                     Text="Priority Behaviour" />
+          <TextBlock Margin="0,6,0,0"
+                     Foreground="#FF4B5563"
+                     TextWrapping="Wrap"
+                     Text="Choose how zone priority should influence switching when more than one mapped zone is active around the same time." />
+
+          <ComboBox Margin="0,16,0,0"
+                    ItemsSource="{Binding PriorityModes}"
+                    SelectedItem="{Binding SelectedPriorityMode}"
+                    DisplayMemberPath="Label" />
+
+          <Border Margin="0,12,0,0"
+                  Padding="12"
+                  Background="White"
+                  BorderBrush="#FFE5E7EB"
+                  BorderThickness="1"
+                  CornerRadius="10">
+            <TextBlock TextWrapping="Wrap"
+                       Foreground="#FF4B5563"
+                       Text="{Binding SelectedPriorityMode.Description}" />
+          </Border>
+          <TextBlock Margin="0,6,0,0"
+                     Foreground="#FFB91C1C"
+                     Text="{Binding PriorityModeError}" />
+        </StackPanel>
+      </Border>
+
+      <Border Padding="14"
+              Background="#FFF8FAFC"
+              BorderBrush="#FFE5E7EB"
+              BorderThickness="1"
+              CornerRadius="10">
+        <DockPanel LastChildFill="False">
+          <TextBlock DockPanel.Dock="Left"
+                     VerticalAlignment="Center"
+                     Text="{Binding SaveStatusMessage}">
+            <TextBlock.Style>
+              <Style TargetType="TextBlock">
+                <Setter Property="Foreground"
+                        Value="#FF4B5563" />
+                <Style.Triggers>
+                  <DataTrigger Binding="{Binding SaveStatusIsError}"
+                               Value="True">
+                    <Setter Property="Foreground"
+                            Value="#FFB91C1C" />
+                  </DataTrigger>
+                </Style.Triggers>
+              </Style>
+            </TextBlock.Style>
+          </TextBlock>
+          <StackPanel DockPanel.Dock="Right"
+                      Orientation="Horizontal"
+                      HorizontalAlignment="Right">
+            <Button Margin="0,0,8,0"
+                    Padding="14,8"
+                    Command="{Binding RestoreDefaultsCommand}"
+                    Content="Restore defaults" />
+            <Button Padding="14,8"
+                    Command="{Binding SaveCommand}"
+                    Content="Save settings" />
           </StackPanel>
-        </Border>
-      </WrapPanel>
+        </DockPanel>
+      </Border>
     </StackPanel>
   </ScrollViewer>
 </UserControl>

--- a/src/InputAwareDisplaySwitcher.App/Views/ZonesProfilesView.xaml
+++ b/src/InputAwareDisplaySwitcher.App/Views/ZonesProfilesView.xaml
@@ -5,12 +5,13 @@
     <Grid.RowDefinitions>
       <RowDefinition Height="Auto" />
       <RowDefinition Height="*" />
+      <RowDefinition Height="Auto" />
     </Grid.RowDefinitions>
 
     <TextBlock Margin="0,0,0,12"
                Foreground="#FF4B5563"
                TextWrapping="Wrap"
-               Text="Zones remain the user-defined logical contexts, and profiles remain logical display intents. This view is the placeholder for editing both." />
+               Text="Create the logical zones and display profiles that device assignments will point to. Keep this list small and descriptive so switching decisions stay easy to understand." />
 
     <Grid Grid.Row="1">
       <Grid.ColumnDefinitions>
@@ -19,53 +20,178 @@
         <ColumnDefinition Width="*" />
       </Grid.ColumnDefinitions>
 
-      <GroupBox Grid.Column="0"
-                Header="Zones">
-        <DataGrid ItemsSource="{Binding Zones}"
-                  AutoGenerateColumns="False"
-                  CanUserAddRows="False"
-                  CanUserDeleteRows="False"
-                  IsReadOnly="True">
-          <DataGrid.Columns>
-            <DataGridTextColumn Header="Name"
-                                Binding="{Binding Name}"
-                                Width="2*" />
-            <DataGridTextColumn Header="Priority"
-                                Binding="{Binding Priority}"
-                                Width="*" />
-            <DataGridTextColumn Header="Profile"
-                                Binding="{Binding PreferredDisplayProfileId}"
-                                Width="2*" />
-            <DataGridCheckBoxColumn Header="Enabled"
-                                    Binding="{Binding IsEnabled}"
-                                    Width="90" />
-          </DataGrid.Columns>
-        </DataGrid>
-      </GroupBox>
+      <Grid Grid.Column="0">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
 
-      <GroupBox Grid.Column="2"
-                Header="Display Profiles">
-        <DataGrid ItemsSource="{Binding Profiles}"
-                  AutoGenerateColumns="False"
-                  CanUserAddRows="False"
-                  CanUserDeleteRows="False"
-                  IsReadOnly="True">
-          <DataGrid.Columns>
-            <DataGridTextColumn Header="Name"
-                                Binding="{Binding Name}"
-                                Width="2*" />
-            <DataGridTextColumn Header="Intent"
-                                Binding="{Binding IntentKind}"
-                                Width="*" />
-            <DataGridTextColumn Header="Description"
-                                Binding="{Binding Description}"
-                                Width="2*" />
-            <DataGridCheckBoxColumn Header="Enabled"
-                                    Binding="{Binding IsEnabled}"
-                                    Width="90" />
-          </DataGrid.Columns>
-        </DataGrid>
-      </GroupBox>
+        <GroupBox Header="Zones">
+          <DataGrid ItemsSource="{Binding Zones}"
+                    AutoGenerateColumns="False"
+                    CanUserAddRows="False"
+                    CanUserDeleteRows="False"
+                    IsReadOnly="True">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="Name"
+                                  Binding="{Binding Name}"
+                                  Width="2*" />
+              <DataGridTextColumn Header="Priority"
+                                  Binding="{Binding Priority}"
+                                  Width="*" />
+              <DataGridTextColumn Header="Profile"
+                                  Binding="{Binding PreferredDisplayProfileId}"
+                                  Width="2*" />
+              <DataGridCheckBoxColumn Header="Enabled"
+                                      Binding="{Binding IsEnabled}"
+                                      Width="90" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </GroupBox>
+
+        <Border Grid.Row="1"
+                Margin="0,16,0,0"
+                Padding="16"
+                Background="#FFF9FAFB"
+                BorderBrush="#FFE5E7EB"
+                BorderThickness="1"
+                CornerRadius="12">
+          <StackPanel>
+            <TextBlock FontSize="16"
+                       FontWeight="SemiBold"
+                       Text="Add Zone" />
+            <TextBlock Margin="0,6,0,0"
+                       Foreground="#FF4B5563"
+                       TextWrapping="Wrap"
+                       Text="Each zone points to one display profile and can be given a priority for suppression behaviour." />
+
+            <TextBlock Margin="0,14,0,4"
+                       FontWeight="SemiBold"
+                       Text="Zone name" />
+            <TextBox Text="{Binding NewZoneName, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Margin="0,12,0,4"
+                       FontWeight="SemiBold"
+                       Text="Description" />
+            <TextBox Text="{Binding NewZoneDescription, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Margin="0,12,0,4"
+                       FontWeight="SemiBold"
+                       Text="Priority" />
+            <TextBox Width="120"
+                     HorizontalAlignment="Left"
+                     Text="{Binding NewZonePriorityText, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Margin="0,12,0,4"
+                       FontWeight="SemiBold"
+                       Text="Display profile" />
+            <ComboBox ItemsSource="{Binding ProfileOptions}"
+                      SelectedItem="{Binding SelectedProfileForZone}"
+                      DisplayMemberPath="DisplayName" />
+
+            <Button Margin="0,16,0,0"
+                    Width="120"
+                    HorizontalAlignment="Left"
+                    Command="{Binding AddZoneCommand}"
+                    Content="Add zone" />
+          </StackPanel>
+        </Border>
+      </Grid>
+
+      <Grid Grid.Column="2">
+        <Grid.RowDefinitions>
+          <RowDefinition Height="*" />
+          <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <GroupBox Header="Display Profiles">
+          <DataGrid ItemsSource="{Binding Profiles}"
+                    AutoGenerateColumns="False"
+                    CanUserAddRows="False"
+                    CanUserDeleteRows="False"
+                    IsReadOnly="True">
+            <DataGrid.Columns>
+              <DataGridTextColumn Header="Name"
+                                  Binding="{Binding Name}"
+                                  Width="2*" />
+              <DataGridTextColumn Header="Intent"
+                                  Binding="{Binding IntentKind}"
+                                  Width="*" />
+              <DataGridTextColumn Header="Description"
+                                  Binding="{Binding Description}"
+                                  Width="2*" />
+              <DataGridCheckBoxColumn Header="Enabled"
+                                      Binding="{Binding IsEnabled}"
+                                      Width="90" />
+            </DataGrid.Columns>
+          </DataGrid>
+        </GroupBox>
+
+        <Border Grid.Row="1"
+                Margin="0,16,0,0"
+                Padding="16"
+                Background="#FFF9FAFB"
+                BorderBrush="#FFE5E7EB"
+                BorderThickness="1"
+                CornerRadius="12">
+          <StackPanel>
+            <TextBlock FontSize="16"
+                       FontWeight="SemiBold"
+                       Text="Add Display Profile" />
+            <TextBlock Margin="0,6,0,0"
+                       Foreground="#FF4B5563"
+                       TextWrapping="Wrap"
+                       Text="Profiles remain logical display intents rather than hard-coded Windows payloads." />
+
+            <TextBlock Margin="0,14,0,4"
+                       FontWeight="SemiBold"
+                       Text="Profile name" />
+            <TextBox Text="{Binding NewProfileName, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Margin="0,12,0,4"
+                       FontWeight="SemiBold"
+                       Text="Description" />
+            <TextBox Text="{Binding NewProfileDescription, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Margin="0,12,0,4"
+                       FontWeight="SemiBold"
+                       Text="Intent" />
+            <ComboBox ItemsSource="{Binding ProfileIntentKinds}"
+                      SelectedItem="{Binding NewProfileIntentKind}" />
+
+            <Button Margin="0,16,0,0"
+                    Width="140"
+                    HorizontalAlignment="Left"
+                    Command="{Binding AddProfileCommand}"
+                    Content="Add profile" />
+          </StackPanel>
+        </Border>
+      </Grid>
     </Grid>
+
+    <Border Grid.Row="2"
+            Margin="0,16,0,0"
+            Padding="14"
+            Background="#FFF8FAFC"
+            BorderBrush="#FFE5E7EB"
+            BorderThickness="1"
+            CornerRadius="10">
+      <TextBlock TextWrapping="Wrap"
+                 Text="{Binding StatusMessage}">
+        <TextBlock.Style>
+          <Style TargetType="TextBlock">
+            <Setter Property="Foreground"
+                    Value="#FF4B5563" />
+            <Style.Triggers>
+              <DataTrigger Binding="{Binding StatusIsError}"
+                           Value="True">
+                <Setter Property="Foreground"
+                        Value="#FFB91C1C" />
+              </DataTrigger>
+            </Style.Triggers>
+          </Style>
+        </TextBlock.Style>
+      </TextBlock>
+    </Border>
   </Grid>
 </UserControl>

--- a/src/InputAwareDisplaySwitcher.Core/Application/AppConfigurationSession.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/AppConfigurationSession.cs
@@ -1,0 +1,62 @@
+using InputAwareDisplaySwitcher.Core.Domain.Configuration;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public delegate void AppConfigurationChangedHandler(AppConfiguration configuration);
+
+public sealed class AppConfigurationSession
+{
+    private readonly ApplicationConfigurationService _configurationService;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private AppConfiguration _currentConfiguration;
+
+    public AppConfigurationSession(
+        ApplicationConfigurationService configurationService,
+        AppConfiguration initialConfiguration)
+    {
+        _configurationService = configurationService ?? throw new ArgumentNullException(nameof(configurationService));
+        _currentConfiguration = initialConfiguration ?? throw new ArgumentNullException(nameof(initialConfiguration));
+    }
+
+    public event AppConfigurationChangedHandler? ConfigurationChanged;
+
+    public AppConfiguration CurrentConfiguration => _currentConfiguration;
+
+    public async Task<AppConfiguration> UpdateAsync(
+        Func<AppConfiguration, AppConfiguration> update,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(update);
+
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var updatedConfiguration = update(_currentConfiguration);
+            await _configurationService.SaveAsync(updatedConfiguration, cancellationToken).ConfigureAwait(false);
+            _currentConfiguration = updatedConfiguration;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        ConfigurationChanged?.Invoke(_currentConfiguration);
+        return _currentConfiguration;
+    }
+
+    public async Task<AppConfiguration> ReloadAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            _currentConfiguration = await _configurationService.LoadAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        ConfigurationChanged?.Invoke(_currentConfiguration);
+        return _currentConfiguration;
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/AutomaticSwitchingController.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/AutomaticSwitchingController.cs
@@ -120,12 +120,17 @@ public sealed class AutomaticSwitchingController
             CurrentZoneId = outcome.ExecutionResult.Success
                 ? outcome.Decision.TargetZoneId
                 : currentState.CurrentZoneId,
+            CurrentZonePriority = outcome.ExecutionResult.Success
+                ? outcome.Resolution.Zone?.Priority ?? currentState.CurrentZonePriority
+                : currentState.CurrentZonePriority,
             CurrentDisplayProfileId = outcome.ExecutionResult.Success
                 ? outcome.Decision.TargetDisplayProfileId
                 : currentState.CurrentDisplayProfileId,
             LastSwitchAtUtc = outcome.ExecutionResult.Success
                 ? outcome.ExecutionResult.RecordedAtUtc
                 : currentState.LastSwitchAtUtc,
+            LastInputAtUtc = outcome.Observation.ObservedAtUtc,
+            LastInputZoneId = outcome.Resolution.Zone?.ZoneId ?? currentState.LastInputZoneId,
             LastMatchedDeviceId = outcome.Decision.MatchedDeviceId ?? currentState.LastMatchedDeviceId
         };
     }
@@ -150,7 +155,10 @@ public sealed class AutomaticSwitchingController
     {
         return new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
+            ["automationEnabled"] = policy.AutomationEnabled.ToString(),
             ["cooldown"] = policy.Cooldown.ToString(),
+            ["recentActivityThreshold"] = policy.RecentActivityThreshold.ToString(),
+            ["priorityMode"] = policy.PriorityMode.ToString(),
             ["manualLockStopsSwitching"] = policy.ManualLockStopsSwitching.ToString(),
             ["allowSameProfileRefresh"] = policy.AllowSameProfileRefresh.ToString()
         };
@@ -161,8 +169,11 @@ public sealed class AutomaticSwitchingController
         return new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase)
         {
             ["currentZoneId"] = state.CurrentZoneId,
+            ["currentZonePriority"] = state.CurrentZonePriority.ToString(),
             ["currentDisplayProfileId"] = state.CurrentDisplayProfileId,
             ["lastSwitchAtUtc"] = state.LastSwitchAtUtc?.ToString("O"),
+            ["lastInputAtUtc"] = state.LastInputAtUtc?.ToString("O"),
+            ["lastInputZoneId"] = state.LastInputZoneId,
             ["isManualSwitchingLocked"] = state.IsManualSwitchingLocked.ToString(),
             ["lastMatchedDeviceId"] = state.LastMatchedDeviceId
         };
@@ -177,10 +188,16 @@ public sealed class AutomaticSwitchingController
         {
             ["previousZoneId"] = previousState.CurrentZoneId,
             ["updatedZoneId"] = updatedState.CurrentZoneId,
+            ["previousZonePriority"] = previousState.CurrentZonePriority.ToString(),
+            ["updatedZonePriority"] = updatedState.CurrentZonePriority.ToString(),
             ["previousDisplayProfileId"] = previousState.CurrentDisplayProfileId,
             ["updatedDisplayProfileId"] = updatedState.CurrentDisplayProfileId,
             ["previousLastSwitchAtUtc"] = previousState.LastSwitchAtUtc?.ToString("O"),
             ["updatedLastSwitchAtUtc"] = updatedState.LastSwitchAtUtc?.ToString("O"),
+            ["previousLastInputAtUtc"] = previousState.LastInputAtUtc?.ToString("O"),
+            ["updatedLastInputAtUtc"] = updatedState.LastInputAtUtc?.ToString("O"),
+            ["previousLastInputZoneId"] = previousState.LastInputZoneId,
+            ["updatedLastInputZoneId"] = updatedState.LastInputZoneId,
             ["previousLastMatchedDeviceId"] = previousState.LastMatchedDeviceId,
             ["updatedLastMatchedDeviceId"] = updatedState.LastMatchedDeviceId,
             ["decisionStatus"] = outcome.Decision.Status.ToString(),

--- a/src/InputAwareDisplaySwitcher.Core/Application/DecisionEngineV1.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DecisionEngineV1.cs
@@ -26,6 +26,11 @@ public sealed class DecisionEngineV1 : IDecisionEngine
                 return Blocked(request, SwitchDecisionReason.MissingDisplayProfile, resolution.Message ?? "The resolved display profile is unavailable.");
         }
 
+        if (!request.Policy.AutomationEnabled)
+        {
+            return Blocked(request, SwitchDecisionReason.AutomationDisabled, "Automatic switching is disabled.");
+        }
+
         if (request.Policy.ManualLockStopsSwitching && request.RuntimeState.IsManualSwitchingLocked)
         {
             return Blocked(request, SwitchDecisionReason.ManualLockActive, "Automatic switching is currently locked.");
@@ -46,6 +51,34 @@ public sealed class DecisionEngineV1 : IDecisionEngine
                     TargetZoneId = resolution.Zone?.ZoneId,
                     TargetDisplayProfileId = resolution.TargetProfile?.DisplayProfileId,
                     CooldownEndsAtUtc = cooldownEndsAtUtc
+                };
+            }
+        }
+
+        if (request.Policy.PriorityMode == PriorityMode.PreferHigherPriorityZone
+            && request.Policy.RecentActivityThreshold > TimeSpan.Zero
+            && request.RuntimeState.LastInputAtUtc.HasValue
+            && !string.IsNullOrWhiteSpace(request.RuntimeState.CurrentZoneId)
+            && !string.IsNullOrWhiteSpace(request.RuntimeState.LastInputZoneId)
+            && string.Equals(request.RuntimeState.CurrentZoneId, request.RuntimeState.LastInputZoneId, StringComparison.OrdinalIgnoreCase)
+            && resolution.Zone is not null
+            && !string.Equals(request.RuntimeState.CurrentZoneId, resolution.Zone.ZoneId, StringComparison.OrdinalIgnoreCase))
+        {
+            var recentActivityEndsAtUtc = request.RuntimeState.LastInputAtUtc.Value.Add(request.Policy.RecentActivityThreshold);
+            var currentZoneWasRecentlyActivated = recentActivityEndsAtUtc > now;
+            var currentZoneHasPriority = request.RuntimeState.CurrentZonePriority > resolution.Zone.Priority;
+
+            if (currentZoneWasRecentlyActivated && currentZoneHasPriority)
+            {
+                return new SwitchDecision
+                {
+                    Status = SwitchDecisionStatus.Blocked,
+                    Reason = SwitchDecisionReason.PrioritySuppressed,
+                    Message = $"Recent activity keeps zone '{request.RuntimeState.CurrentZoneId}' active until {recentActivityEndsAtUtc:O} because it has higher priority.",
+                    EvaluatedAtUtc = now,
+                    MatchedDeviceId = resolution.MatchedDevice?.DeviceId,
+                    TargetZoneId = resolution.Zone.ZoneId,
+                    TargetDisplayProfileId = resolution.TargetProfile?.DisplayProfileId
                 };
             }
         }

--- a/src/InputAwareDisplaySwitcher.Core/Application/DeviceAssignmentState.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DeviceAssignmentState.cs
@@ -1,0 +1,8 @@
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public enum DeviceAssignmentState
+{
+    Assigned = 0,
+    Unassigned = 1,
+    UnknownZone = 2
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DeviceManagementEntry.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DeviceManagementEntry.cs
@@ -1,0 +1,40 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed record DeviceManagementEntry
+{
+    public required string EntryId { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public DeviceKind DeviceKind { get; init; } = DeviceKind.Unknown;
+
+    public string? PersistedDeviceId { get; init; }
+
+    public PersistedDeviceIdentity? PersistedDevice { get; init; }
+
+    public RuntimeDeviceObservation? Observation { get; init; }
+
+    public bool IsDetectedThisSession { get; init; }
+
+    public bool IsAvailableThisSession { get; init; }
+
+    public bool IsEnabled { get; init; } = true;
+
+    public string? AssignedZoneId { get; init; }
+
+    public string? AssignedZoneName { get; init; }
+
+    public DeviceAssignmentState AssignmentState { get; init; } = DeviceAssignmentState.Unassigned;
+
+    public string StableIdentitySummary { get; init; } = string.Empty;
+
+    public string MetadataSummary { get; init; } = string.Empty;
+
+    public DateTimeOffset? LastSeenAtUtc { get; init; }
+
+    public bool CanPersistEdits { get; init; }
+
+    public string? PersistenceWarning { get; init; }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DeviceManagementService.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DeviceManagementService.cs
@@ -1,0 +1,291 @@
+using System.Security.Cryptography;
+using System.Text;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class DeviceManagementService
+{
+    public IReadOnlyList<DeviceManagementEntry> BuildEntries(
+        DeviceRegistrySnapshot snapshot,
+        IReadOnlyList<RuntimeDeviceObservation>? observations)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        var runtimeObservations = observations ?? [];
+        var entries = new List<DeviceManagementEntry>();
+        var matchedDeviceIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var observation in runtimeObservations)
+        {
+            var matchedDevice = FindMatchedDevice(snapshot, observation);
+            if (!string.IsNullOrWhiteSpace(matchedDevice?.DeviceId))
+            {
+                matchedDeviceIds.Add(matchedDevice.DeviceId);
+            }
+
+            entries.Add(CreateEntry(snapshot, observation, matchedDevice));
+        }
+
+        foreach (var device in snapshot.Devices)
+        {
+            if (matchedDeviceIds.Contains(device.DeviceId))
+            {
+                continue;
+            }
+
+            entries.Add(CreateEntry(snapshot, observation: null, persistedDevice: device));
+        }
+
+        return entries
+            .OrderByDescending(entry => entry.IsDetectedThisSession)
+            .ThenBy(entry => entry.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.StableIdentitySummary, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    public DeviceRegistrySnapshot ApplyEdits(
+        DeviceRegistrySnapshot snapshot,
+        DeviceManagementEntry entry,
+        string friendlyName,
+        string? assignedZoneId,
+        DateTimeOffset updatedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        ArgumentNullException.ThrowIfNull(entry);
+
+        var normalizedFriendlyName = NormalizeFriendlyName(friendlyName, entry);
+        var normalizedZoneId = string.IsNullOrWhiteSpace(assignedZoneId)
+            ? null
+            : assignedZoneId.Trim();
+
+        var updatedDevice = entry.PersistedDevice is null
+            ? CreatePersistedDevice(entry, normalizedFriendlyName, normalizedZoneId, updatedAtUtc)
+            : entry.PersistedDevice with
+            {
+                FriendlyName = normalizedFriendlyName,
+                AssignedZoneId = normalizedZoneId
+            };
+
+        var devices = snapshot.Devices.ToList();
+        var existingIndex = devices.FindIndex(device =>
+            string.Equals(device.DeviceId, updatedDevice.DeviceId, StringComparison.OrdinalIgnoreCase));
+
+        if (existingIndex >= 0)
+        {
+            devices[existingIndex] = updatedDevice;
+        }
+        else
+        {
+            devices.Add(updatedDevice);
+        }
+
+        return snapshot with
+        {
+            Devices = devices
+        };
+    }
+
+    private static DeviceManagementEntry CreateEntry(
+        DeviceRegistrySnapshot snapshot,
+        RuntimeDeviceObservation? observation,
+        PersistedDeviceIdentity? persistedDevice)
+    {
+        var assignedZoneId = persistedDevice?.AssignedZoneId;
+        var assignedZone = snapshot.FindZone(assignedZoneId);
+        var displayName = ResolveDisplayName(observation, persistedDevice);
+        var canPersistEdits = persistedDevice is not null
+            || (observation is not null && !string.IsNullOrWhiteSpace(DevicePersistenceKeyResolver.GetPreferredDurableKey(observation)));
+
+        return new DeviceManagementEntry
+        {
+            EntryId = persistedDevice?.DeviceId
+                ?? observation?.SessionDeviceId
+                ?? Guid.NewGuid().ToString("N"),
+            DisplayName = displayName,
+            DeviceKind = persistedDevice?.DeviceKind ?? observation?.DeviceKind ?? DeviceKind.Unknown,
+            PersistedDeviceId = persistedDevice?.DeviceId,
+            PersistedDevice = persistedDevice,
+            Observation = observation,
+            IsDetectedThisSession = observation is not null,
+            IsAvailableThisSession = observation?.IsAvailableThisSession ?? false,
+            IsEnabled = persistedDevice?.IsEnabled ?? true,
+            AssignedZoneId = assignedZoneId,
+            AssignedZoneName = assignedZone?.Name,
+            AssignmentState = ResolveAssignmentState(assignedZoneId, assignedZone),
+            StableIdentitySummary = BuildStableIdentitySummary(observation, persistedDevice),
+            MetadataSummary = BuildMetadataSummary(observation, persistedDevice),
+            LastSeenAtUtc = observation?.LastSeenAtUtc ?? observation?.ObservedAtUtc ?? persistedDevice?.LastConfirmedAtUtc,
+            CanPersistEdits = canPersistEdits,
+            PersistenceWarning = canPersistEdits
+                ? null
+                : "This device only exposed a session-scoped handle, so it cannot be safely saved yet."
+        };
+    }
+
+    private static PersistedDeviceIdentity? FindMatchedDevice(
+        DeviceRegistrySnapshot snapshot,
+        RuntimeDeviceObservation observation)
+    {
+        var candidateKeys = observation.GetCandidatePersistenceKeys();
+        return snapshot.Devices.FirstOrDefault(device => DevicePersistenceKeyResolver
+            .GetPersistenceKeys(device)
+            .Intersect(candidateKeys, StringComparer.OrdinalIgnoreCase)
+            .Any());
+    }
+
+    private static PersistedDeviceIdentity CreatePersistedDevice(
+        DeviceManagementEntry entry,
+        string friendlyName,
+        string? assignedZoneId,
+        DateTimeOffset updatedAtUtc)
+    {
+        var observation = entry.Observation
+            ?? throw new InvalidOperationException("A runtime observation is required to create a new persisted device.");
+
+        var preferredDurableKey = DevicePersistenceKeyResolver.GetPreferredDurableKey(observation);
+        if (string.IsNullOrWhiteSpace(preferredDurableKey))
+        {
+            throw new InvalidOperationException("The device does not yet expose a durable persistence key.");
+        }
+
+        return new PersistedDeviceIdentity
+        {
+            DeviceId = CreateDeviceId(observation.DeviceKind, preferredDurableKey),
+            FriendlyName = friendlyName,
+            DeviceKind = observation.DeviceKind,
+            PreferredPersistenceKey = preferredDurableKey,
+            IdentityEvidence = new DeviceIdentityEvidence
+            {
+                RawDevicePath = observation.RawDevicePath,
+                NormalizedDevicePath = observation.NormalizedDevicePath,
+                InstanceId = observation.InstanceId,
+                VendorId = observation.VendorId,
+                ProductId = observation.ProductId,
+                FriendlyName = observation.FriendlyName
+            },
+            AssignedZoneId = assignedZoneId,
+            LastConfirmedAtUtc = updatedAtUtc,
+            IsEnabled = true
+        };
+    }
+
+    private static string CreateDeviceId(DeviceKind deviceKind, string preferredKey)
+    {
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(preferredKey));
+        var hash = Convert.ToHexString(hashBytes[..6]).ToLowerInvariant();
+        return $"{deviceKind.ToString().ToLowerInvariant()}-{hash}";
+    }
+
+    private static DeviceAssignmentState ResolveAssignmentState(string? assignedZoneId, ZoneDefinition? assignedZone)
+    {
+        if (string.IsNullOrWhiteSpace(assignedZoneId))
+        {
+            return DeviceAssignmentState.Unassigned;
+        }
+
+        return assignedZone is null
+            ? DeviceAssignmentState.UnknownZone
+            : DeviceAssignmentState.Assigned;
+    }
+
+    private static string ResolveDisplayName(RuntimeDeviceObservation? observation, PersistedDeviceIdentity? persistedDevice)
+    {
+        if (!string.IsNullOrWhiteSpace(persistedDevice?.FriendlyName))
+        {
+            return persistedDevice.FriendlyName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(observation?.FriendlyName))
+        {
+            return observation.FriendlyName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(persistedDevice?.IdentityEvidence.FriendlyName))
+        {
+            return persistedDevice.IdentityEvidence.FriendlyName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(persistedDevice?.DeviceId))
+        {
+            return persistedDevice.DeviceId;
+        }
+
+        return observation?.SessionDeviceId ?? "Unnamed device";
+    }
+
+    private static string NormalizeFriendlyName(string friendlyName, DeviceManagementEntry entry)
+    {
+        if (!string.IsNullOrWhiteSpace(friendlyName))
+        {
+            return friendlyName.Trim();
+        }
+
+        return entry.DisplayName;
+    }
+
+    private static string BuildStableIdentitySummary(
+        RuntimeDeviceObservation? observation,
+        PersistedDeviceIdentity? persistedDevice)
+    {
+        if (!string.IsNullOrWhiteSpace(persistedDevice?.PreferredPersistenceKey))
+        {
+            return persistedDevice.PreferredPersistenceKey;
+        }
+
+        if (observation is null)
+        {
+            return "No stable identity evidence recorded.";
+        }
+
+        return DevicePersistenceKeyResolver.GetPreferredDurableKey(observation)
+            ?? "No durable key yet. Runtime handle only.";
+    }
+
+    private static string BuildMetadataSummary(
+        RuntimeDeviceObservation? observation,
+        PersistedDeviceIdentity? persistedDevice)
+    {
+        var parts = new List<string>();
+        var evidence = persistedDevice?.IdentityEvidence;
+
+        AddIfPresent(parts, evidence?.FriendlyName ?? observation?.FriendlyName);
+        AddIfPresent(parts, FormatVidPid(evidence?.VendorId ?? observation?.VendorId, evidence?.ProductId ?? observation?.ProductId));
+        AddIfPresent(parts, evidence?.Manufacturer);
+        AddIfPresent(parts, evidence?.EnumeratorName);
+
+        return parts.Count == 0
+            ? "No extra hardware metadata recorded."
+            : string.Join(" | ", parts.Distinct(StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static string? FormatVidPid(string? vendorId, string? productId)
+    {
+        if (string.IsNullOrWhiteSpace(vendorId) && string.IsNullOrWhiteSpace(productId))
+        {
+            return null;
+        }
+
+        var parts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(vendorId))
+        {
+            parts.Add($"VID_{vendorId}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(productId))
+        {
+            parts.Add($"PID_{productId}");
+        }
+
+        return string.Join(" / ", parts);
+    }
+
+    private static void AddIfPresent(ICollection<string> values, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            values.Add(value);
+        }
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DevicePersistenceKeyResolver.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DevicePersistenceKeyResolver.cs
@@ -1,0 +1,52 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+internal static class DevicePersistenceKeyResolver
+{
+    public static IEnumerable<string> GetPersistenceKeys(PersistedDeviceIdentity device)
+    {
+        ArgumentNullException.ThrowIfNull(device);
+
+        if (!string.IsNullOrWhiteSpace(device.PreferredPersistenceKey))
+        {
+            yield return device.PreferredPersistenceKey;
+        }
+
+        var evidence = device.IdentityEvidence;
+
+        var instanceKey = RuntimeDeviceObservation.BuildInstanceKey(evidence.InstanceId);
+        if (!string.IsNullOrWhiteSpace(instanceKey))
+        {
+            yield return instanceKey;
+        }
+
+        var pathKey = RuntimeDeviceObservation.BuildPathKey(evidence.NormalizedDevicePath);
+        if (!string.IsNullOrWhiteSpace(pathKey))
+        {
+            yield return pathKey;
+        }
+
+        var rawPathKey = RuntimeDeviceObservation.BuildRawPathKey(evidence.RawDevicePath);
+        if (!string.IsNullOrWhiteSpace(rawPathKey))
+        {
+            yield return rawPathKey;
+        }
+
+        var vidPidKey = RuntimeDeviceObservation.BuildVidPidKey(device.DeviceKind, evidence.VendorId, evidence.ProductId);
+        if (!string.IsNullOrWhiteSpace(vidPidKey))
+        {
+            yield return vidPidKey;
+        }
+    }
+
+    public static string? GetPreferredDurableKey(RuntimeDeviceObservation observation)
+    {
+        ArgumentNullException.ThrowIfNull(observation);
+
+        return RuntimeDeviceObservation.BuildInstanceKey(observation.InstanceId)
+            ?? RuntimeDeviceObservation.BuildPathKey(observation.NormalizedDevicePath)
+            ?? RuntimeDeviceObservation.BuildRawPathKey(observation.RawDevicePath)
+            ?? RuntimeDeviceObservation.BuildVidPidKey(observation.DeviceKind, observation.VendorId, observation.ProductId);
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/DeviceRegistryService.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/DeviceRegistryService.cs
@@ -56,7 +56,7 @@ public sealed class DeviceRegistryService
         ArgumentNullException.ThrowIfNull(snapshot);
 
         var candidateKeys = observation.GetCandidatePersistenceKeys();
-        var matchedDevice = snapshot.Devices.FirstOrDefault(device => GetPersistenceKeys(device)
+        var matchedDevice = snapshot.Devices.FirstOrDefault(device => DevicePersistenceKeyResolver.GetPersistenceKeys(device)
             .Intersect(candidateKeys, StringComparer.OrdinalIgnoreCase)
             .Any());
 
@@ -70,7 +70,7 @@ public sealed class DeviceRegistryService
             };
         }
 
-        var matchedKey = GetPersistenceKeys(matchedDevice)
+        var matchedKey = DevicePersistenceKeyResolver.GetPersistenceKeys(matchedDevice)
             .Intersect(candidateKeys, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault();
 
@@ -148,40 +148,6 @@ public sealed class DeviceRegistryService
             MatchedByPersistenceKey = matchedKey,
             Message = $"Device '{matchedDevice.FriendlyName}' resolved to zone '{zone.Name}' and profile '{profile.Name}'."
         };
-    }
-
-    private static IEnumerable<string> GetPersistenceKeys(PersistedDeviceIdentity device)
-    {
-        if (!string.IsNullOrWhiteSpace(device.PreferredPersistenceKey))
-        {
-            yield return device.PreferredPersistenceKey;
-        }
-
-        var evidence = device.IdentityEvidence;
-
-        var instanceKey = RuntimeDeviceObservation.BuildInstanceKey(evidence.InstanceId);
-        if (!string.IsNullOrWhiteSpace(instanceKey))
-        {
-            yield return instanceKey;
-        }
-
-        var pathKey = RuntimeDeviceObservation.BuildPathKey(evidence.NormalizedDevicePath);
-        if (!string.IsNullOrWhiteSpace(pathKey))
-        {
-            yield return pathKey;
-        }
-
-        var rawPathKey = RuntimeDeviceObservation.BuildRawPathKey(evidence.RawDevicePath);
-        if (!string.IsNullOrWhiteSpace(rawPathKey))
-        {
-            yield return rawPathKey;
-        }
-
-        var vidPidKey = RuntimeDeviceObservation.BuildVidPidKey(device.DeviceKind, evidence.VendorId, evidence.ProductId);
-        if (!string.IsNullOrWhiteSpace(vidPidKey))
-        {
-            yield return vidPidKey;
-        }
     }
 
     private static void Upsert<T>(

--- a/src/InputAwareDisplaySwitcher.Core/Application/IInputDeviceSnapshotProvider.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/IInputDeviceSnapshotProvider.cs
@@ -1,0 +1,8 @@
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public interface IInputDeviceSnapshotProvider
+{
+    Task<IReadOnlyList<RuntimeDeviceObservation>> GetCurrentDevicesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/InputAwareDisplaySwitcher.Core/Application/SwitchingSettingsService.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Application/SwitchingSettingsService.cs
@@ -1,0 +1,119 @@
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Core.Application;
+
+public sealed class SwitchingSettingsService
+{
+    private const int MaximumSeconds = 86400;
+
+    public SwitchingSettingsInput CreateInput(SwitchingPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        return new SwitchingSettingsInput
+        {
+            AutomationEnabled = policy.AutomationEnabled,
+            CooldownSecondsText = ((int)policy.Cooldown.TotalSeconds).ToString(),
+            RecentActivityThresholdSecondsText = ((int)policy.RecentActivityThreshold.TotalSeconds).ToString(),
+            PriorityMode = policy.PriorityMode,
+            ManualLockStopsSwitching = policy.ManualLockStopsSwitching,
+            AllowSameProfileRefresh = policy.AllowSameProfileRefresh
+        };
+    }
+
+    public SwitchingSettingsValidationResult Validate(SwitchingSettingsInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var cooldownResult = ParseSeconds(input.CooldownSecondsText, "Cooldown");
+        var recentActivityResult = ParseSeconds(input.RecentActivityThresholdSecondsText, "Recent activity threshold");
+        var priorityError = Enum.IsDefined(input.PriorityMode)
+            ? null
+            : "Priority behaviour must be one of the supported options.";
+
+        if (cooldownResult.ErrorMessage is not null
+            || recentActivityResult.ErrorMessage is not null
+            || priorityError is not null)
+        {
+            return new SwitchingSettingsValidationResult
+            {
+                CooldownError = cooldownResult.ErrorMessage,
+                RecentActivityThresholdError = recentActivityResult.ErrorMessage,
+                PriorityModeError = priorityError
+            };
+        }
+
+        return new SwitchingSettingsValidationResult
+        {
+            Policy = new SwitchingPolicy
+            {
+                AutomationEnabled = input.AutomationEnabled,
+                Cooldown = TimeSpan.FromSeconds(cooldownResult.Seconds),
+                RecentActivityThreshold = TimeSpan.FromSeconds(recentActivityResult.Seconds),
+                PriorityMode = input.PriorityMode,
+                ManualLockStopsSwitching = input.ManualLockStopsSwitching,
+                AllowSameProfileRefresh = input.AllowSameProfileRefresh
+            }
+        };
+    }
+
+    private static NumericValidationResult ParseSeconds(string? text, string label)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return NumericValidationResult.Invalid($"{label} is required.");
+        }
+
+        if (!int.TryParse(text, out var seconds))
+        {
+            return NumericValidationResult.Invalid($"{label} must be a whole number of seconds.");
+        }
+
+        if (seconds < 0)
+        {
+            return NumericValidationResult.Invalid($"{label} cannot be negative.");
+        }
+
+        if (seconds > MaximumSeconds)
+        {
+            return NumericValidationResult.Invalid($"{label} must stay at or below {MaximumSeconds} seconds.");
+        }
+
+        return NumericValidationResult.Valid(seconds);
+    }
+
+    private readonly record struct NumericValidationResult(int Seconds, string? ErrorMessage)
+    {
+        public static NumericValidationResult Valid(int seconds) => new(seconds, null);
+
+        public static NumericValidationResult Invalid(string errorMessage) => new(0, errorMessage);
+    }
+}
+
+public sealed record SwitchingSettingsInput
+{
+    public bool AutomationEnabled { get; init; } = true;
+
+    public string CooldownSecondsText { get; init; } = "30";
+
+    public string RecentActivityThresholdSecondsText { get; init; } = "15";
+
+    public PriorityMode PriorityMode { get; init; } = PriorityMode.MostRecentInputWins;
+
+    public bool ManualLockStopsSwitching { get; init; } = true;
+
+    public bool AllowSameProfileRefresh { get; init; }
+}
+
+public sealed record SwitchingSettingsValidationResult
+{
+    public SwitchingPolicy? Policy { get; init; }
+
+    public string? CooldownError { get; init; }
+
+    public string? RecentActivityThresholdError { get; init; }
+
+    public string? PriorityModeError { get; init; }
+
+    public bool IsValid => Policy is not null;
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Diagnostics/DiagnosticEventTypes.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Diagnostics/DiagnosticEventTypes.cs
@@ -11,6 +11,8 @@ public static class DiagnosticEventTypes
     public const string ConfigurationLoadFailed = "configuration.load_failed";
     public const string ConfigurationSaved = "configuration.saved";
     public const string ConfigurationSaveFailed = "configuration.save_failed";
+    public const string DeviceSnapshotRefreshed = "devices.snapshot_refreshed";
+    public const string DeviceSnapshotRefreshFailed = "devices.snapshot_refresh_failed";
     public const string SwitchingControllerStarted = "switching.controller_started";
     public const string SwitchingControllerStopped = "switching.controller_stopped";
     public const string InputActivityDetected = "input.activity_detected";

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/ApplicationRuntimeState.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/ApplicationRuntimeState.cs
@@ -4,9 +4,15 @@ public sealed record ApplicationRuntimeState
 {
     public string? CurrentZoneId { get; init; }
 
+    public int CurrentZonePriority { get; init; }
+
     public string? CurrentDisplayProfileId { get; init; }
 
     public DateTimeOffset? LastSwitchAtUtc { get; init; }
+
+    public DateTimeOffset? LastInputAtUtc { get; init; }
+
+    public string? LastInputZoneId { get; init; }
 
     public bool IsManualSwitchingLocked { get; init; }
 

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/PriorityMode.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/PriorityMode.cs
@@ -1,0 +1,7 @@
+namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+public enum PriorityMode
+{
+    MostRecentInputWins = 0,
+    PreferHigherPriorityZone = 1
+}

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionReason.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchDecisionReason.cs
@@ -3,12 +3,14 @@ namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
 public enum SwitchDecisionReason
 {
     Allowed = 0,
-    UnknownDevice = 1,
-    DisabledDevice = 2,
-    UnmappedDevice = 3,
-    DisabledZone = 4,
-    MissingDisplayProfile = 5,
-    ManualLockActive = 6,
-    CooldownActive = 7,
-    AlreadyActive = 8
+    AutomationDisabled = 1,
+    UnknownDevice = 2,
+    DisabledDevice = 3,
+    UnmappedDevice = 4,
+    DisabledZone = 5,
+    MissingDisplayProfile = 6,
+    ManualLockActive = 7,
+    CooldownActive = 8,
+    PrioritySuppressed = 9,
+    AlreadyActive = 10
 }

--- a/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchingPolicy.cs
+++ b/src/InputAwareDisplaySwitcher.Core/Domain/Switching/SwitchingPolicy.cs
@@ -2,7 +2,13 @@ namespace InputAwareDisplaySwitcher.Core.Domain.Switching;
 
 public sealed record SwitchingPolicy
 {
+    public bool AutomationEnabled { get; init; } = true;
+
     public TimeSpan Cooldown { get; init; } = TimeSpan.FromSeconds(30);
+
+    public TimeSpan RecentActivityThreshold { get; init; } = TimeSpan.FromSeconds(15);
+
+    public PriorityMode PriorityMode { get; init; } = PriorityMode.MostRecentInputWins;
 
     public bool ManualLockStopsSwitching { get; init; } = true;
 

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Configuration/JsonAppConfigurationStore.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Configuration/JsonAppConfigurationStore.cs
@@ -114,9 +114,41 @@ public sealed class JsonAppConfigurationStore : IAppConfigurationStore
         return configuration with
         {
             Version = configuration.Version <= 0 ? AppConfiguration.CurrentVersion : configuration.Version,
-            DeviceRegistry = configuration.DeviceRegistry ?? new DeviceRegistrySnapshot(),
-            SwitchingPolicy = configuration.SwitchingPolicy ?? new SwitchingPolicy(),
+            DeviceRegistry = SanitizeDeviceRegistry(configuration.DeviceRegistry),
+            SwitchingPolicy = SanitizePolicy(configuration.SwitchingPolicy),
             Preferences = configuration.Preferences ?? new AppPreferences()
+        };
+    }
+
+    private static DeviceRegistrySnapshot SanitizeDeviceRegistry(DeviceRegistrySnapshot? registry)
+    {
+        if (registry is null)
+        {
+            return new DeviceRegistrySnapshot();
+        }
+
+        return registry with
+        {
+            Devices = registry.Devices ?? [],
+            Zones = registry.Zones ?? [],
+            DisplayProfiles = registry.DisplayProfiles ?? []
+        };
+    }
+
+    private static SwitchingPolicy SanitizePolicy(SwitchingPolicy? policy)
+    {
+        var defaults = new SwitchingPolicy();
+        var candidate = policy ?? defaults;
+
+        return candidate with
+        {
+            Cooldown = candidate.Cooldown < TimeSpan.Zero ? defaults.Cooldown : candidate.Cooldown,
+            RecentActivityThreshold = candidate.RecentActivityThreshold < TimeSpan.Zero
+                ? defaults.RecentActivityThreshold
+                : candidate.RecentActivityThreshold,
+            PriorityMode = Enum.IsDefined(candidate.PriorityMode)
+                ? candidate.PriorityMode
+                : defaults.PriorityMode
         };
     }
 
@@ -129,7 +161,10 @@ public sealed class JsonAppConfigurationStore : IAppConfigurationStore
             ["deviceCount"] = configuration.DeviceRegistry.Devices.Count.ToString(),
             ["zoneCount"] = configuration.DeviceRegistry.Zones.Count.ToString(),
             ["profileCount"] = configuration.DeviceRegistry.DisplayProfiles.Count.ToString(),
+            ["automationEnabled"] = configuration.SwitchingPolicy.AutomationEnabled.ToString(),
             ["cooldown"] = configuration.SwitchingPolicy.Cooldown.ToString(),
+            ["recentActivityThreshold"] = configuration.SwitchingPolicy.RecentActivityThreshold.ToString(),
+            ["priorityMode"] = configuration.SwitchingPolicy.PriorityMode.ToString(),
             ["manualLockStopsSwitching"] = configuration.SwitchingPolicy.ManualLockStopsSwitching.ToString(),
             ["allowSameProfileRefresh"] = configuration.SwitchingPolicy.AllowSameProfileRefresh.ToString(),
             ["isManualSwitchingLocked"] = configuration.Preferences.IsManualSwitchingLocked.ToString()

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsInputDeviceSnapshotProvider.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsInputDeviceSnapshotProvider.cs
@@ -1,0 +1,55 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Diagnostics;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.Input;
+
+public sealed class WindowsInputDeviceSnapshotProvider : IInputDeviceSnapshotProvider
+{
+    private readonly WindowsRawInputDeviceEnumerator _enumerator = new();
+    private readonly IDiagnosticsService _diagnostics;
+
+    public WindowsInputDeviceSnapshotProvider(IDiagnosticsService? diagnostics = null)
+    {
+        _diagnostics = diagnostics ?? NullDiagnosticsService.Instance;
+    }
+
+    public Task<IReadOnlyList<RuntimeDeviceObservation>> GetCurrentDevicesAsync(CancellationToken cancellationToken = default)
+    {
+        return Task.Run<IReadOnlyList<RuntimeDeviceObservation>>(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var devices = _enumerator.GetCurrentDevices();
+
+                _diagnostics.Record(
+                    DiagnosticCategories.Input,
+                    DiagnosticEventTypes.DeviceSnapshotRefreshed,
+                    "Current input devices were enumerated.",
+                    details: new Dictionary<string, string?>
+                    {
+                        ["deviceCount"] = devices.Count.ToString()
+                    });
+
+                return devices;
+            }
+            catch (Exception exception)
+            {
+                _diagnostics.Record(
+                    DiagnosticCategories.Input,
+                    DiagnosticEventTypes.DeviceSnapshotRefreshFailed,
+                    "Input device enumeration failed.",
+                    DiagnosticSeverity.Warning,
+                    new Dictionary<string, string?>
+                    {
+                        ["exceptionType"] = exception.GetType().Name,
+                        ["exceptionMessage"] = exception.Message
+                    });
+
+                return Array.Empty<RuntimeDeviceObservation>();
+            }
+        }, cancellationToken);
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsRawInputDeviceEnumerator.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsRawInputDeviceEnumerator.cs
@@ -1,0 +1,419 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.Input;
+
+internal sealed class WindowsRawInputDeviceEnumerator
+{
+    private static readonly Regex VidPidRegex = new(@"VID_([0-9A-F]{4}).*PID_([0-9A-F]{4})", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    public IReadOnlyList<RuntimeDeviceObservation> GetCurrentDevices()
+    {
+        uint deviceCount = 0;
+        var countResult = WindowsRawInputInterop.GetRawInputDeviceList(
+            nint.Zero,
+            ref deviceCount,
+            (uint)Marshal.SizeOf<WindowsRawInputInterop.RawInputDeviceListEntry>());
+
+        if (countResult == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        if (deviceCount == 0)
+        {
+            return Array.Empty<RuntimeDeviceObservation>();
+        }
+
+        var elementSize = Marshal.SizeOf<WindowsRawInputInterop.RawInputDeviceListEntry>();
+        var buffer = Marshal.AllocHGlobal((int)(deviceCount * elementSize));
+
+        try
+        {
+            var listResult = WindowsRawInputInterop.GetRawInputDeviceList(
+                buffer,
+                ref deviceCount,
+                (uint)elementSize);
+
+            if (listResult == uint.MaxValue)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            var devices = new List<RuntimeDeviceObservation>();
+            for (var index = 0; index < deviceCount; index++)
+            {
+                var current = buffer + (index * elementSize);
+                var deviceEntry = Marshal.PtrToStructure<WindowsRawInputInterop.RawInputDeviceListEntry>(current);
+                var deviceKind = ToDeviceKind(deviceEntry.DeviceType);
+
+                if (deviceKind == DeviceKind.Unknown)
+                {
+                    continue;
+                }
+
+                devices.Add(CreateObservation(deviceEntry.DeviceHandle, deviceKind));
+            }
+
+            return devices
+                .OrderBy(device => device.DeviceKind)
+                .ThenBy(device => device.FriendlyName, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(device => device.NormalizedDevicePath, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static RuntimeDeviceObservation CreateObservation(nint deviceHandle, DeviceKind deviceKind)
+    {
+        var observedAtUtc = DateTimeOffset.UtcNow;
+
+        try
+        {
+            var deviceInfo = GetDeviceInfo(deviceHandle);
+            var rawDevicePath = GetDeviceName(deviceHandle);
+            var pathInfo = DevicePathInfo.Create(rawDevicePath);
+            var metadata = SetupApiMetadataLookup.TryResolve(pathInfo);
+            var (vendorId, productId) = ParseVidPid(rawDevicePath, deviceInfo);
+            var friendlyName = FirstNonEmpty(
+                metadata.FriendlyName,
+                metadata.DeviceDescription,
+                metadata.DeviceInstanceId,
+                rawDevicePath);
+
+            return new RuntimeDeviceObservation
+            {
+                SessionDeviceId = WindowsRawInputInterop.FormatHandle(deviceHandle),
+                DeviceKind = deviceKind,
+                RawDevicePath = NullIfWhiteSpace(rawDevicePath),
+                NormalizedDevicePath = NullIfWhiteSpace(pathInfo.NormalizedDeviceInterfacePath),
+                InstanceId = NullIfWhiteSpace(metadata.DeviceInstanceId),
+                VendorId = NullIfWhiteSpace(vendorId),
+                ProductId = NullIfWhiteSpace(productId),
+                FriendlyName = NullIfWhiteSpace(friendlyName),
+                ObservedAtUtc = observedAtUtc,
+                LastSeenAtUtc = observedAtUtc,
+                IsAvailableThisSession = true
+            };
+        }
+        catch (Win32Exception)
+        {
+            return new RuntimeDeviceObservation
+            {
+                SessionDeviceId = WindowsRawInputInterop.FormatHandle(deviceHandle),
+                DeviceKind = deviceKind,
+                FriendlyName = $"{deviceKind} {WindowsRawInputInterop.FormatHandle(deviceHandle)}",
+                ObservedAtUtc = observedAtUtc,
+                LastSeenAtUtc = observedAtUtc,
+                IsAvailableThisSession = true
+            };
+        }
+    }
+
+    private static WindowsRawInputInterop.RawInputDeviceInfo GetDeviceInfo(nint deviceHandle)
+    {
+        var info = new WindowsRawInputInterop.RawInputDeviceInfo
+        {
+            Size = (uint)Marshal.SizeOf<WindowsRawInputInterop.RawInputDeviceInfo>()
+        };
+
+        var size = info.Size;
+        var result = WindowsRawInputInterop.GetRawInputDeviceInfo(
+            deviceHandle,
+            WindowsRawInputInterop.DeviceInfoCommand,
+            ref info,
+            ref size);
+
+        if (result == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        return info;
+    }
+
+    private static string GetDeviceName(nint deviceHandle)
+    {
+        uint size = 0;
+        var queryResult = WindowsRawInputInterop.GetRawInputDeviceInfo(
+            deviceHandle,
+            WindowsRawInputInterop.DeviceNameCommand,
+            nint.Zero,
+            ref size);
+
+        if (queryResult == uint.MaxValue)
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        if (size == 0)
+        {
+            return string.Empty;
+        }
+
+        var buffer = Marshal.AllocHGlobal((int)(size * sizeof(char)));
+        try
+        {
+            var nameSize = size;
+            var nameResult = WindowsRawInputInterop.GetRawInputDeviceInfo(
+                deviceHandle,
+                WindowsRawInputInterop.DeviceNameCommand,
+                buffer,
+                ref nameSize);
+
+            if (nameResult == uint.MaxValue)
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+
+            return Marshal.PtrToStringUni(buffer) ?? string.Empty;
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    private static (string? VendorId, string? ProductId) ParseVidPid(
+        string rawDevicePath,
+        WindowsRawInputInterop.RawInputDeviceInfo deviceInfo)
+    {
+        var match = VidPidRegex.Match(rawDevicePath);
+        if (match.Success)
+        {
+            return (match.Groups[1].Value.ToUpperInvariant(), match.Groups[2].Value.ToUpperInvariant());
+        }
+
+        if (deviceInfo.DeviceType == WindowsRawInputInterop.RawInputHid)
+        {
+            return ($"{deviceInfo.Union.Hid.VendorId:X4}", $"{deviceInfo.Union.Hid.ProductId:X4}");
+        }
+
+        return (null, null);
+    }
+
+    private static DeviceKind ToDeviceKind(uint rawType)
+    {
+        return rawType switch
+        {
+            WindowsRawInputInterop.RawInputKeyboard => DeviceKind.Keyboard,
+            WindowsRawInputInterop.RawInputMouse => DeviceKind.Mouse,
+            _ => DeviceKind.Unknown
+        };
+    }
+
+    private static string? NullIfWhiteSpace(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string FirstNonEmpty(params string?[] values)
+    {
+        return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+    }
+
+    private sealed record DevicePathInfo(string RawDevicePath, string NormalizedDeviceInterfacePath)
+    {
+        public static DevicePathInfo Create(string rawDevicePath)
+        {
+            if (string.IsNullOrWhiteSpace(rawDevicePath))
+            {
+                return new DevicePathInfo(string.Empty, string.Empty);
+            }
+
+            if (rawDevicePath.StartsWith(@"\??\", StringComparison.Ordinal))
+            {
+                return new DevicePathInfo(rawDevicePath, @"\\?\" + rawDevicePath[4..]);
+            }
+
+            return new DevicePathInfo(rawDevicePath, rawDevicePath);
+        }
+    }
+
+    private sealed record SetupApiMetadata(
+        string DeviceInstanceId,
+        string FriendlyName,
+        string DeviceDescription);
+
+    private static class SetupApiMetadataLookup
+    {
+        public static SetupApiMetadata TryResolve(DevicePathInfo pathInfo)
+        {
+            if (string.IsNullOrWhiteSpace(pathInfo.NormalizedDeviceInterfacePath))
+            {
+                return new SetupApiMetadata(string.Empty, string.Empty, string.Empty);
+            }
+
+            nint deviceInfoSet = nint.Zero;
+
+            try
+            {
+                deviceInfoSet = WindowsSetupApiInterop.SetupDiCreateDeviceInfoList(nint.Zero, nint.Zero);
+                if (deviceInfoSet == nint.Zero || deviceInfoSet == WindowsSetupApiInterop.InvalidHandleValue)
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                var interfaceData = new WindowsSetupApiInterop.DeviceInterfaceData
+                {
+                    Size = (uint)Marshal.SizeOf<WindowsSetupApiInterop.DeviceInterfaceData>()
+                };
+
+                if (!WindowsSetupApiInterop.SetupDiOpenDeviceInterface(
+                    deviceInfoSet,
+                    pathInfo.NormalizedDeviceInterfacePath,
+                    0,
+                    ref interfaceData))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+
+                var deviceInfoData = new WindowsSetupApiInterop.DeviceInfoData
+                {
+                    Size = (uint)Marshal.SizeOf<WindowsSetupApiInterop.DeviceInfoData>()
+                };
+
+                uint requiredSize = 0;
+                var detailResult = WindowsSetupApiInterop.SetupDiGetDeviceInterfaceDetail(
+                    deviceInfoSet,
+                    ref interfaceData,
+                    nint.Zero,
+                    0,
+                    ref requiredSize,
+                    ref deviceInfoData);
+
+                if (!detailResult)
+                {
+                    var errorCode = Marshal.GetLastWin32Error();
+                    if (errorCode != WindowsSetupApiInterop.ErrorInsufficientBuffer)
+                    {
+                        throw new Win32Exception(errorCode);
+                    }
+                }
+
+                return new SetupApiMetadata(
+                    GetDeviceInstanceId(deviceInfoSet, deviceInfoData),
+                    GetRegistryStringProperty(deviceInfoSet, deviceInfoData, WindowsSetupApiInterop.PropertyFriendlyName),
+                    GetRegistryStringProperty(deviceInfoSet, deviceInfoData, WindowsSetupApiInterop.PropertyDeviceDescription));
+            }
+            catch (Win32Exception)
+            {
+                return new SetupApiMetadata(string.Empty, string.Empty, string.Empty);
+            }
+            finally
+            {
+                if (deviceInfoSet != nint.Zero && deviceInfoSet != WindowsSetupApiInterop.InvalidHandleValue)
+                {
+                    WindowsSetupApiInterop.SetupDiDestroyDeviceInfoList(deviceInfoSet);
+                }
+            }
+        }
+
+        private static string GetDeviceInstanceId(nint deviceInfoSet, WindowsSetupApiInterop.DeviceInfoData deviceInfoData)
+        {
+            var buffer = new StringBuilder(256);
+            if (WindowsSetupApiInterop.SetupDiGetDeviceInstanceId(
+                deviceInfoSet,
+                ref deviceInfoData,
+                buffer,
+                buffer.Capacity,
+                out var requiredSize))
+            {
+                return buffer.ToString();
+            }
+
+            var errorCode = Marshal.GetLastWin32Error();
+            if (errorCode != WindowsSetupApiInterop.ErrorInsufficientBuffer)
+            {
+                return string.Empty;
+            }
+
+            buffer = new StringBuilder(requiredSize + 1);
+            if (!WindowsSetupApiInterop.SetupDiGetDeviceInstanceId(
+                deviceInfoSet,
+                ref deviceInfoData,
+                buffer,
+                buffer.Capacity,
+                out _))
+            {
+                return string.Empty;
+            }
+
+            return buffer.ToString();
+        }
+
+        private static string GetRegistryStringProperty(
+            nint deviceInfoSet,
+            WindowsSetupApiInterop.DeviceInfoData deviceInfoData,
+            uint property)
+        {
+            if (!TryGetRegistryProperty(deviceInfoSet, deviceInfoData, property, out var regType, out var buffer))
+            {
+                return string.Empty;
+            }
+
+            if (regType != WindowsSetupApiInterop.RegistryString || buffer.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            return Encoding.Unicode.GetString(buffer).TrimEnd('\0').Trim();
+        }
+
+        private static bool TryGetRegistryProperty(
+            nint deviceInfoSet,
+            WindowsSetupApiInterop.DeviceInfoData deviceInfoData,
+            uint property,
+            out uint regType,
+            out byte[] buffer)
+        {
+            regType = 0;
+            buffer = [];
+            uint requiredSize = 0;
+
+            WindowsSetupApiInterop.SetupDiGetDeviceRegistryProperty(
+                deviceInfoSet,
+                ref deviceInfoData,
+                property,
+                out regType,
+                [],
+                0,
+                out requiredSize);
+
+            var errorCode = Marshal.GetLastWin32Error();
+            if (errorCode == WindowsSetupApiInterop.ErrorInvalidData
+                || errorCode == WindowsSetupApiInterop.ErrorNotFound
+                || requiredSize == 0)
+            {
+                return false;
+            }
+
+            if (errorCode != WindowsSetupApiInterop.ErrorInsufficientBuffer)
+            {
+                return false;
+            }
+
+            buffer = new byte[requiredSize];
+            if (!WindowsSetupApiInterop.SetupDiGetDeviceRegistryProperty(
+                deviceInfoSet,
+                ref deviceInfoData,
+                property,
+                out regType,
+                buffer,
+                requiredSize,
+                out _))
+            {
+                buffer = [];
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsRawInputInterop.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsRawInputInterop.cs
@@ -1,0 +1,96 @@
+using System.Runtime.InteropServices;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.Input;
+
+internal static class WindowsRawInputInterop
+{
+    public const uint DeviceNameCommand = 0x20000007;
+    public const uint DeviceInfoCommand = 0x2000000b;
+
+    public const uint RawInputMouse = 0;
+    public const uint RawInputKeyboard = 1;
+    public const uint RawInputHid = 2;
+
+    [DllImport("User32.dll", SetLastError = true)]
+    public static extern uint GetRawInputDeviceList(
+        nint rawInputDeviceList,
+        ref uint deviceCount,
+        uint elementSize);
+
+    [DllImport("User32.dll", SetLastError = true, EntryPoint = "GetRawInputDeviceInfoW")]
+    public static extern uint GetRawInputDeviceInfo(
+        nint deviceHandle,
+        uint command,
+        nint data,
+        ref uint dataSize);
+
+    [DllImport("User32.dll", SetLastError = true, EntryPoint = "GetRawInputDeviceInfoW", CharSet = CharSet.Unicode)]
+    public static extern uint GetRawInputDeviceInfo(
+        nint deviceHandle,
+        uint command,
+        ref RawInputDeviceInfo data,
+        ref uint dataSize);
+
+    public static string FormatHandle(nint handle)
+    {
+        return $"0x{handle.ToInt64():X16}";
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawInputDeviceListEntry
+    {
+        public nint DeviceHandle;
+        public uint DeviceType;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawInputDeviceInfo
+    {
+        public uint Size;
+        public uint DeviceType;
+        public RawInputDeviceInfoUnion Union;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct RawInputDeviceInfoUnion
+    {
+        [FieldOffset(0)]
+        public RawInputMouseInfo Mouse;
+
+        [FieldOffset(0)]
+        public RawInputKeyboardInfo Keyboard;
+
+        [FieldOffset(0)]
+        public RawInputHidInfo Hid;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawInputMouseInfo
+    {
+        public uint Id;
+        public uint NumberOfButtons;
+        public uint SampleRate;
+        public bool HasHorizontalWheel;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawInputKeyboardInfo
+    {
+        public uint Type;
+        public uint SubType;
+        public uint KeyboardMode;
+        public uint NumberOfFunctionKeys;
+        public uint NumberOfIndicators;
+        public uint NumberOfKeysTotal;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RawInputHidInfo
+    {
+        public uint VendorId;
+        public uint ProductId;
+        public uint VersionNumber;
+        public ushort UsagePage;
+        public ushort Usage;
+    }
+}

--- a/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsSetupApiInterop.cs
+++ b/src/InputAwareDisplaySwitcher.Infrastructure/Windows/Input/WindowsSetupApiInterop.cs
@@ -1,0 +1,81 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace InputAwareDisplaySwitcher.Infrastructure.Windows.Input;
+
+internal static class WindowsSetupApiInterop
+{
+    public const int ErrorInsufficientBuffer = 122;
+    public const int ErrorInvalidData = 13;
+    public const int ErrorNotFound = 1168;
+
+    public const uint PropertyDeviceDescription = 0x00000000;
+    public const uint PropertyFriendlyName = 0x0000000C;
+
+    public const uint RegistryString = 1;
+
+    public static readonly nint InvalidHandleValue = new(-1);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    public static extern nint SetupDiCreateDeviceInfoList(nint classGuid, nint hwndParent);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetupDiDestroyDeviceInfoList(nint deviceInfoSet);
+
+    [DllImport("setupapi.dll", SetLastError = true, EntryPoint = "SetupDiOpenDeviceInterfaceW", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetupDiOpenDeviceInterface(
+        nint deviceInfoSet,
+        string devicePath,
+        uint openFlags,
+        ref DeviceInterfaceData interfaceData);
+
+    [DllImport("setupapi.dll", SetLastError = true, EntryPoint = "SetupDiGetDeviceInterfaceDetailW", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetupDiGetDeviceInterfaceDetail(
+        nint deviceInfoSet,
+        ref DeviceInterfaceData interfaceData,
+        nint deviceInterfaceDetailData,
+        uint deviceInterfaceDetailDataSize,
+        ref uint requiredSize,
+        ref DeviceInfoData deviceInfoData);
+
+    [DllImport("setupapi.dll", SetLastError = true, EntryPoint = "SetupDiGetDeviceInstanceIdW", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetupDiGetDeviceInstanceId(
+        nint deviceInfoSet,
+        ref DeviceInfoData deviceInfoData,
+        StringBuilder deviceInstanceId,
+        int deviceInstanceIdSize,
+        out int requiredSize);
+
+    [DllImport("setupapi.dll", SetLastError = true, EntryPoint = "SetupDiGetDeviceRegistryPropertyW", CharSet = CharSet.Unicode)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetupDiGetDeviceRegistryProperty(
+        nint deviceInfoSet,
+        ref DeviceInfoData deviceInfoData,
+        uint property,
+        out uint propertyRegDataType,
+        byte[] propertyBuffer,
+        uint propertyBufferSize,
+        out uint requiredSize);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DeviceInterfaceData
+    {
+        public uint Size;
+        public Guid InterfaceClassGuid;
+        public uint Flags;
+        public nuint Reserved;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DeviceInfoData
+    {
+        public uint Size;
+        public Guid ClassGuid;
+        public uint DeviceInstance;
+        public nuint Reserved;
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/DecisionEngineV1Tests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/DecisionEngineV1Tests.cs
@@ -56,6 +56,22 @@ public sealed class DecisionEngineV1Tests
     }
 
     [Fact]
+    public void Evaluate_BlocksWhenAutomationIsDisabled()
+    {
+        var request = CreateRequest(
+            CreateResolvedResolution(),
+            policy: new SwitchingPolicy
+            {
+                AutomationEnabled = false
+            });
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.AutomationDisabled, decision.Reason);
+    }
+
+    [Fact]
     public void Evaluate_BlocksWhenCooldownIsActive()
     {
         var now = DateTimeOffset.UtcNow;
@@ -76,6 +92,33 @@ public sealed class DecisionEngineV1Tests
         Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
         Assert.Equal(SwitchDecisionReason.CooldownActive, decision.Reason);
         Assert.NotNull(decision.CooldownEndsAtUtc);
+    }
+
+    [Fact]
+    public void Evaluate_BlocksLowerPriorityZoneDuringRecentActivityWindow()
+    {
+        var now = DateTimeOffset.UtcNow;
+        var request = CreateRequest(
+            CreateResolvedResolution(priority: 5),
+            new ApplicationRuntimeState
+            {
+                CurrentZoneId = "living-room",
+                CurrentZonePriority = 10,
+                LastInputAtUtc = now.AddSeconds(-5),
+                LastInputZoneId = "living-room"
+            },
+            new SwitchingPolicy
+            {
+                Cooldown = TimeSpan.Zero,
+                RecentActivityThreshold = TimeSpan.FromSeconds(15),
+                PriorityMode = PriorityMode.PreferHigherPriorityZone
+            },
+            now);
+
+        var decision = _engine.Evaluate(request);
+
+        Assert.Equal(SwitchDecisionStatus.Blocked, decision.Status);
+        Assert.Equal(SwitchDecisionReason.PrioritySuppressed, decision.Reason);
     }
 
     [Fact]
@@ -125,14 +168,15 @@ public sealed class DecisionEngineV1Tests
         };
     }
 
-    private static DeviceRegistryResolution CreateResolvedResolution()
+    private static DeviceRegistryResolution CreateResolvedResolution(int priority = 10)
     {
         var device = CreateDevice();
         var zone = new ZoneDefinition
         {
             ZoneId = "desk",
             Name = "Desk",
-            PreferredDisplayProfileId = "desk-profile"
+            PreferredDisplayProfileId = "desk-profile",
+            Priority = priority
         };
         var profile = new DisplayProfile
         {

--- a/tests/InputAwareDisplaySwitcher.Tests/DeviceManagementServiceTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/DeviceManagementServiceTests.cs
@@ -1,0 +1,182 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Devices;
+using InputAwareDisplaySwitcher.Core.Domain.Profiles;
+using InputAwareDisplaySwitcher.Core.Domain.Zones;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class DeviceManagementServiceTests
+{
+    private readonly DeviceManagementService _service = new();
+
+    [Fact]
+    public void BuildEntries_ProjectsDetectedPersistedDeviceWithAssignedZone()
+    {
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard",
+                    AssignedZoneId = "desk"
+                }
+            ],
+            Zones =
+            [
+                new ZoneDefinition
+                {
+                    ZoneId = "desk",
+                    Name = "Desk",
+                    PreferredDisplayProfileId = "desk-profile",
+                    Priority = 10
+                }
+            ],
+            DisplayProfiles =
+            [
+                new DisplayProfile
+                {
+                    DisplayProfileId = "desk-profile",
+                    Name = "Desk Only",
+                    IntentKind = DisplayProfileIntentKind.ExternalOnly
+                }
+            ]
+        };
+
+        var entries = _service.BuildEntries(snapshot,
+        [
+            new RuntimeDeviceObservation
+            {
+                SessionDeviceId = "raw:0001",
+                DeviceKind = DeviceKind.Keyboard,
+                InstanceId = "desk-keyboard",
+                FriendlyName = "USB Keyboard",
+                ObservedAtUtc = DateTimeOffset.UtcNow,
+                LastSeenAtUtc = DateTimeOffset.UtcNow
+            }
+        ]);
+
+        var entry = Assert.Single(entries);
+        Assert.True(entry.IsDetectedThisSession);
+        Assert.Equal("Desk Keyboard", entry.DisplayName);
+        Assert.Equal("desk", entry.AssignedZoneId);
+        Assert.Equal("Desk", entry.AssignedZoneName);
+        Assert.Equal(DeviceAssignmentState.Assigned, entry.AssignmentState);
+        Assert.True(entry.CanPersistEdits);
+    }
+
+    [Fact]
+    public void BuildEntries_SurfacesUnassignedPersistedDevicesClearly()
+    {
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "mouse-1",
+                    FriendlyName = "Travel Mouse",
+                    DeviceKind = DeviceKind.Mouse,
+                    PreferredPersistenceKey = "instance:travel-mouse"
+                }
+            ]
+        };
+
+        var entry = Assert.Single(_service.BuildEntries(snapshot, []));
+
+        Assert.False(entry.IsDetectedThisSession);
+        Assert.Equal(DeviceAssignmentState.Unassigned, entry.AssignmentState);
+        Assert.Null(entry.AssignedZoneId);
+        Assert.Equal("instance:travel-mouse", entry.StableIdentitySummary);
+    }
+
+    [Fact]
+    public void ApplyEdits_UpdatesFriendlyNameAndZoneForPersistedDevice()
+    {
+        var snapshot = new DeviceRegistrySnapshot
+        {
+            Devices =
+            [
+                new PersistedDeviceIdentity
+                {
+                    DeviceId = "keyboard-1",
+                    FriendlyName = "Desk Keyboard",
+                    DeviceKind = DeviceKind.Keyboard,
+                    PreferredPersistenceKey = "instance:desk-keyboard"
+                }
+            ]
+        };
+        var entry = Assert.Single(_service.BuildEntries(snapshot, []));
+
+        var updated = _service.ApplyEdits(
+            snapshot,
+            entry,
+            "Living Room Keyboard",
+            "living-room",
+            DateTimeOffset.UtcNow);
+
+        var device = Assert.Single(updated.Devices);
+        Assert.Equal("Living Room Keyboard", device.FriendlyName);
+        Assert.Equal("living-room", device.AssignedZoneId);
+    }
+
+    [Fact]
+    public void ApplyEdits_CreatesPersistedMappingForNewObservedDevice()
+    {
+        var snapshot = new DeviceRegistrySnapshot();
+        var observedEntry = Assert.Single(_service.BuildEntries(snapshot,
+        [
+            new RuntimeDeviceObservation
+            {
+                SessionDeviceId = "raw:0002",
+                DeviceKind = DeviceKind.Keyboard,
+                InstanceId = "new-keyboard",
+                FriendlyName = "Wireless Keyboard",
+                ObservedAtUtc = DateTimeOffset.UtcNow
+            }
+        ]));
+
+        var updated = _service.ApplyEdits(
+            snapshot,
+            observedEntry,
+            "Living Room Keyboard",
+            "living-room",
+            DateTimeOffset.UtcNow);
+
+        var device = Assert.Single(updated.Devices);
+        Assert.Equal("Living Room Keyboard", device.FriendlyName);
+        Assert.Equal("living-room", device.AssignedZoneId);
+        Assert.Equal("instance:new-keyboard", device.PreferredPersistenceKey);
+        Assert.StartsWith("keyboard-", device.DeviceId, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyEdits_RejectsSessionOnlyDevices()
+    {
+        var snapshot = new DeviceRegistrySnapshot();
+        var entry = Assert.Single(_service.BuildEntries(snapshot,
+        [
+            new RuntimeDeviceObservation
+            {
+                SessionDeviceId = "raw:0003",
+                DeviceKind = DeviceKind.Mouse,
+                FriendlyName = "Unknown Mouse",
+                ObservedAtUtc = DateTimeOffset.UtcNow
+            }
+        ]));
+
+        Assert.False(entry.CanPersistEdits);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => _service.ApplyEdits(
+            snapshot,
+            entry,
+            "Unsafe Mouse",
+            null,
+            DateTimeOffset.UtcNow));
+
+        Assert.Contains("durable persistence key", exception.Message);
+    }
+}

--- a/tests/InputAwareDisplaySwitcher.Tests/JsonAppConfigurationStoreTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/JsonAppConfigurationStoreTests.cs
@@ -26,7 +26,10 @@ public sealed class JsonAppConfigurationStoreTests : IDisposable
         Assert.Empty(configuration.DeviceRegistry.Devices);
         Assert.Empty(configuration.DeviceRegistry.Zones);
         Assert.Empty(configuration.DeviceRegistry.DisplayProfiles);
+        Assert.True(configuration.SwitchingPolicy.AutomationEnabled);
         Assert.Equal(TimeSpan.FromSeconds(30), configuration.SwitchingPolicy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(15), configuration.SwitchingPolicy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.MostRecentInputWins, configuration.SwitchingPolicy.PriorityMode);
         Assert.False(configuration.Preferences.IsManualSwitchingLocked);
         Assert.Contains(diagnostics.Records, record => record.EventType == DiagnosticEventTypes.ConfigurationMissingFile);
     }
@@ -92,7 +95,10 @@ public sealed class JsonAppConfigurationStoreTests : IDisposable
             },
             SwitchingPolicy = new SwitchingPolicy
             {
+                AutomationEnabled = false,
                 Cooldown = TimeSpan.FromMinutes(2),
+                RecentActivityThreshold = TimeSpan.FromSeconds(20),
+                PriorityMode = PriorityMode.PreferHigherPriorityZone,
                 ManualLockStopsSwitching = true,
                 AllowSameProfileRefresh = true
             },
@@ -108,7 +114,10 @@ public sealed class JsonAppConfigurationStoreTests : IDisposable
         Assert.Single(loaded.DeviceRegistry.Devices);
         Assert.Single(loaded.DeviceRegistry.Zones);
         Assert.Single(loaded.DeviceRegistry.DisplayProfiles);
+        Assert.False(loaded.SwitchingPolicy.AutomationEnabled);
         Assert.Equal(TimeSpan.FromMinutes(2), loaded.SwitchingPolicy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(20), loaded.SwitchingPolicy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.PreferHigherPriorityZone, loaded.SwitchingPolicy.PriorityMode);
         Assert.True(loaded.SwitchingPolicy.AllowSameProfileRefresh);
         Assert.True(loaded.Preferences.IsManualSwitchingLocked);
         Assert.Contains(diagnostics.Records, record => record.EventType == DiagnosticEventTypes.ConfigurationSaved);
@@ -136,7 +145,10 @@ public sealed class JsonAppConfigurationStoreTests : IDisposable
         Assert.NotNull(configuration.DeviceRegistry);
         Assert.NotNull(configuration.SwitchingPolicy);
         Assert.NotNull(configuration.Preferences);
+        Assert.True(configuration.SwitchingPolicy.AutomationEnabled);
         Assert.Equal(TimeSpan.FromSeconds(30), configuration.SwitchingPolicy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(15), configuration.SwitchingPolicy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.MostRecentInputWins, configuration.SwitchingPolicy.PriorityMode);
         Assert.False(configuration.Preferences.IsManualSwitchingLocked);
     }
 
@@ -161,7 +173,44 @@ public sealed class JsonAppConfigurationStoreTests : IDisposable
         var configuration = await store.LoadAsync();
 
         Assert.Equal(TimeSpan.FromSeconds(30), configuration.SwitchingPolicy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(15), configuration.SwitchingPolicy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.MostRecentInputWins, configuration.SwitchingPolicy.PriorityMode);
         Assert.False(configuration.Preferences.IsManualSwitchingLocked);
+    }
+
+    [Fact]
+    public async Task LoadAsync_WhenDurationsAreNegative_UsesSafeDefaults()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var filePath = Path.Combine(_tempDirectory, "config.json");
+        await File.WriteAllTextAsync(filePath, """
+            {
+              "version": 1,
+              "deviceRegistry": {
+                "devices": null,
+                "zones": null,
+                "displayProfiles": null
+              },
+              "switchingPolicy": {
+                "automationEnabled": false,
+                "cooldown": "-00:00:05",
+                "recentActivityThreshold": "-00:00:03",
+                "priorityMode": "PreferHigherPriorityZone"
+              }
+            }
+            """);
+
+        var store = new JsonAppConfigurationStore(filePath, new DiagnosticsService());
+
+        var configuration = await store.LoadAsync();
+
+        Assert.Empty(configuration.DeviceRegistry.Devices);
+        Assert.Empty(configuration.DeviceRegistry.Zones);
+        Assert.Empty(configuration.DeviceRegistry.DisplayProfiles);
+        Assert.False(configuration.SwitchingPolicy.AutomationEnabled);
+        Assert.Equal(TimeSpan.FromSeconds(30), configuration.SwitchingPolicy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(15), configuration.SwitchingPolicy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.PreferHigherPriorityZone, configuration.SwitchingPolicy.PriorityMode);
     }
 
     public void Dispose()

--- a/tests/InputAwareDisplaySwitcher.Tests/SwitchingSettingsServiceTests.cs
+++ b/tests/InputAwareDisplaySwitcher.Tests/SwitchingSettingsServiceTests.cs
@@ -1,0 +1,59 @@
+using InputAwareDisplaySwitcher.Core.Application;
+using InputAwareDisplaySwitcher.Core.Domain.Switching;
+
+namespace InputAwareDisplaySwitcher.Tests;
+
+public sealed class SwitchingSettingsServiceTests
+{
+    private readonly SwitchingSettingsService _service = new();
+
+    [Fact]
+    public void Validate_RejectsNegativeCooldown()
+    {
+        var result = _service.Validate(new SwitchingSettingsInput
+        {
+            CooldownSecondsText = "-1",
+            RecentActivityThresholdSecondsText = "15"
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Cooldown cannot be negative.", result.CooldownError);
+    }
+
+    [Fact]
+    public void Validate_RejectsUnsupportedPriorityMode()
+    {
+        var result = _service.Validate(new SwitchingSettingsInput
+        {
+            CooldownSecondsText = "30",
+            RecentActivityThresholdSecondsText = "15",
+            PriorityMode = (PriorityMode)999
+        });
+
+        Assert.False(result.IsValid);
+        Assert.Equal("Priority behaviour must be one of the supported options.", result.PriorityModeError);
+    }
+
+    [Fact]
+    public void Validate_BuildsPolicyForValidInputAndPreservesExistingFlags()
+    {
+        var result = _service.Validate(new SwitchingSettingsInput
+        {
+            AutomationEnabled = false,
+            CooldownSecondsText = "45",
+            RecentActivityThresholdSecondsText = "20",
+            PriorityMode = PriorityMode.PreferHigherPriorityZone,
+            ManualLockStopsSwitching = false,
+            AllowSameProfileRefresh = true
+        });
+
+        Assert.True(result.IsValid);
+        Assert.NotNull(result.Policy);
+        Assert.False(result.Policy.AutomationEnabled);
+        Assert.Equal(TimeSpan.FromSeconds(45), result.Policy.Cooldown);
+        Assert.Equal(TimeSpan.FromSeconds(20), result.Policy.RecentActivityThreshold);
+        Assert.Equal(PriorityMode.PreferHigherPriorityZone, result.Policy.PriorityMode);
+        Assert.False(result.Policy.ManualLockStopsSwitching);
+        Assert.True(result.Policy.AllowSameProfileRefresh);
+    }
+}


### PR DESCRIPTION
## Summary

Implement issues #13 and #14 by replacing the placeholder configuration screens with working WPF/MVVM flows for device management and switching rules. The app can now show live detected input devices, let users set app-local friendly names and zone assignments, and configure automation, cooldown, recent-activity, and priority behaviour with validated JSON-backed persistence.

## Related Issue

Closes #13  
Closes #14

## Scope of Changes

- Added a live Devices management screen that merges runtime device snapshots with persisted mappings, supports alias editing and zone assignment, and clearly surfaces unassigned or non-persistable devices
- Added a working Rules & Settings screen with validation, save/default flows, and persistence for automation, cooldown, recent activity threshold, and priority mode
- Extended the app/config/runtime plumbing and tests to support reactive config updates, safe persistence, and the new switching-policy behaviour

## Validation

Ran automated validation with:

- `cmd.exe /c dotnet test "tests\InputAwareDisplaySwitcher.Tests\InputAwareDisplaySwitcher.Tests.csproj"`
- `cmd.exe /c dotnet build input-aware-display-switcher.sln`

Also reviewed the integration path to ensure:
- device aliases and zone assignments save through the existing JSON config flow
- invalid settings values are rejected safely
- the Devices screen has a recovery path when no zones exist
- new policy settings affect core decision logic rather than only the UI

## Documentation Impact

- [x] No documentation changes required
- [ ] Documentation updated in this PR

## Checklist

- [x] The change is focused and within issue scope
- [x] Relevant docs were updated where needed
- [x] Validation appropriate to the change was completed
- [x] No unrelated implementation or cleanup was bundled into this PR